### PR TITLE
Activate info tests

### DIFF
--- a/co_sim_io/impl/info.hpp
+++ b/co_sim_io/impl/info.hpp
@@ -91,7 +91,7 @@ public:
         const bool key_exists = Has(I_Key);
         if (key_exists) {
             const auto& r_val = mOptions.at(I_Key);
-            CO_SIM_IO_ERROR_IF(r_val->GetDataTypeName() != Internals::Name(TDataType())) << "Wrong DataType!" << std::endl;
+            CO_SIM_IO_ERROR_IF(r_val->GetDataTypeName() != Internals::Name(TDataType())) << "Wrong DataType! Trying to get \"" << I_Key << "\" which is of type \"" << r_val->GetDataTypeName() << "\" with \"" << Internals::Name(TDataType()) << "\"!" << std::endl;
             return *static_cast<const TDataType*>(r_val->GetData());
         } else {
             return TDataType();
@@ -117,7 +117,20 @@ public:
         mOptions[I_Key] = std::make_shared<Internals::InfoData<TDataType>>(I_Value);
     }
 
-    // TODO do we need "erase", "clear", "size" ?
+    void Erase(const std::string& I_Key)
+    {
+        mOptions.erase(I_Key);
+    }
+
+    void Clear()
+    {
+        mOptions.clear();
+    }
+
+    std::size_t Size() const
+    {
+        return mOptions.size();
+    }
 
 private:
     std::unordered_map<std::string, std::shared_ptr<Internals::InfoDataBase>> mOptions;

--- a/co_sim_io/impl/macros.hpp
+++ b/co_sim_io/impl/macros.hpp
@@ -23,8 +23,7 @@ the code where the CoSimIO is included
     #include <iostream>
     #include <stdexcept>
     struct err { // helper struct to mimic behavior of KRATOS_ERROR
-    err() {std::cout << "Error: ";}
-    ~err() noexcept(false) { throw std::exception(); } // destructors are noexcept by default
+    ~err() noexcept(false) { throw std::runtime_error("Error: "); } // destructors are noexcept by default
     };
     #define CO_SIM_IO_ERROR (err(), std::cout)
 #endif

--- a/tests/co_sim_io/internals/test_info.cpp
+++ b/tests/co_sim_io/internals/test_info.cpp
@@ -16,44 +16,81 @@
 
 namespace CoSimIO {
 
-namespace {
-
-void AddLocalInt(Info& rInfo)
-{
-    // this puts a local variable into the info
-    // it should still giv the correct result even after the local var goes out of scope
-    int local_var = 15;
-    REQUIRE_FALSE(rInfo.Has("local_var_int"));
-
-    rInfo.Set<int>("local_var_int", local_var);
-}
-
-}
-
-TEST_CASE("test_info_basics")
+TEST_CASE("test_info_int")
 {
     Info info;
 
-    REQUIRE_FALSE(info.Has("Some_value_non_existant"));
+    REQUIRE_FALSE(info.Has("echo_level"));
 
     info.Set<int>("echo_level", 1);
 
     REQUIRE(info.Has("echo_level"));
 
-    std::cout << info.Get<int>("echo_level") << std::endl << std::endl;
-
-    REQUIRE(info.Get<int>("echo_level") == 1); // not working
+    REQUIRE(info.Get<int>("echo_level") == 1);
 }
 
-TEST_CASE("test_info_local_vars")
+TEST_CASE("test_info_double")
 {
     Info info;
 
-    AddLocalInt(info);
+    REQUIRE_FALSE(info.Has("tolerance"));
 
-    REQUIRE(info.Has("local_var_int"));
+    info.Set<double>("tolerance", 1.5);
 
-    REQUIRE(info.Get<int>("local_var_int") == 15); // not working
+    REQUIRE(info.Has("tolerance"));
+
+    REQUIRE(info.Get<double>("tolerance") == Approx(1.5));
+}
+
+TEST_CASE("test_info_bool")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("print_sth"));
+
+    info.Set<bool>("print_sth", false);
+
+    REQUIRE(info.Has("print_sth"));
+
+    REQUIRE(info.Get<bool>("print_sth") == false);
+}
+
+TEST_CASE("test_info_string")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("identifier"));
+
+    info.Set<std::string>("identifier", "pressure");
+
+    REQUIRE(info.Has("identifier"));
+
+    REQUIRE(info.Get<std::string>("identifier") == "pressure");
+}
+
+TEST_CASE("test_info_many_values")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("identifier"));
+    REQUIRE_FALSE(info.Has("is_converged"));
+    REQUIRE_FALSE(info.Has("tol"));
+    REQUIRE_FALSE(info.Has("echo_level"));
+
+    info.Set<std::string>("identifier", "velocity_interface");
+    info.Set<bool>("is_converged", true);
+    info.Set<double>("tol", 0.008);
+    info.Set<int>("echo_level", 2);
+
+    REQUIRE(info.Has("identifier"));
+    REQUIRE(info.Has("is_converged"));
+    REQUIRE(info.Has("tol"));
+    REQUIRE(info.Has("echo_level"));
+
+    REQUIRE(info.Get<std::string>("identifier") == "velocity_interface");
+    REQUIRE(info.Get<bool>("is_converged") == true);
+    REQUIRE(info.Get<double>("tol") == Approx(0.008));
+    REQUIRE(info.Get<int>("echo_level") == 2);
 }
 
 } // namespace CoSimIO

--- a/tests/co_sim_io/internals/test_info.cpp
+++ b/tests/co_sim_io/internals/test_info.cpp
@@ -16,7 +16,7 @@
 
 namespace CoSimIO {
 
-TEST_CASE("test_info_basics_int")
+TEST_CASE("info_basics_int")
 {
     Info info;
 
@@ -29,7 +29,7 @@ TEST_CASE("test_info_basics_int")
     REQUIRE(info.Get<int>("echo_level") == 1);
 }
 
-TEST_CASE("test_info_basics_double")
+TEST_CASE("info_basics_double")
 {
     Info info;
 
@@ -42,7 +42,7 @@ TEST_CASE("test_info_basics_double")
     REQUIRE(info.Get<double>("tolerance") == Approx(1.5));
 }
 
-TEST_CASE("test_info_basics_bool")
+TEST_CASE("info_basics_bool")
 {
     Info info;
 
@@ -55,7 +55,7 @@ TEST_CASE("test_info_basics_bool")
     REQUIRE(info.Get<bool>("print_sth") == false);
 }
 
-TEST_CASE("test_info_basics_string")
+TEST_CASE("info_basics_string")
 {
     Info info;
 
@@ -68,7 +68,7 @@ TEST_CASE("test_info_basics_string")
     REQUIRE(info.Get<std::string>("identifier") == "pressure");
 }
 
-TEST_CASE("test_info_wrong_type")
+TEST_CASE("info_wrong_type")
 {
     Info info;
 
@@ -77,10 +77,10 @@ TEST_CASE("test_info_wrong_type")
     info.Set<std::string>("identifier", "pressure");
 
     REQUIRE(info.Has("identifier"));
-    REQUIRE_THROWS_WITH(info.Get<int>("identifier"), "std::exception"); // TODO find a better way of testing this
+    REQUIRE_THROWS_WITH(info.Get<int>("identifier"), "Error: "); // TODO find a better way of testing this
 }
 
-TEST_CASE("test_info_many_values")
+TEST_CASE("info_many_values")
 {
     Info info;
 
@@ -105,7 +105,7 @@ TEST_CASE("test_info_many_values")
     REQUIRE(info.Get<int>("echo_level") == 2);
 }
 
-TEST_CASE("test_info_set_alreay_existing")
+TEST_CASE("info_set_alreay_existing")
 {
     Info info;
 
@@ -119,7 +119,7 @@ TEST_CASE("test_info_set_alreay_existing")
     REQUIRE(info.Get<std::string>("identifier") == "pressure");
 }
 
-TEST_CASE("test_info_set_alreay_existing_different_data_type")
+TEST_CASE("info_set_alreay_existing_different_data_type")
 {
     Info info;
 
@@ -133,7 +133,7 @@ TEST_CASE("test_info_set_alreay_existing_different_data_type")
     REQUIRE(info.Get<int>("identifier") == 15);
 }
 
-TEST_CASE("test_info_size")
+TEST_CASE("info_size")
 {
     Info info;
     REQUIRE(info.Size() == 0);
@@ -148,7 +148,7 @@ TEST_CASE("test_info_size")
     REQUIRE(info.Size() == 4);
 }
 
-TEST_CASE("test_info_clear")
+TEST_CASE("info_clear")
 {
     Info info;
     REQUIRE(info.Size() == 0);
@@ -166,7 +166,7 @@ TEST_CASE("test_info_clear")
     REQUIRE(info.Size() == 0);
 }
 
-TEST_CASE("test_info_erase")
+TEST_CASE("info_erase")
 {
     Info info;
     REQUIRE(info.Size() == 0);

--- a/tests/co_sim_io/internals/test_info.cpp
+++ b/tests/co_sim_io/internals/test_info.cpp
@@ -42,7 +42,7 @@ TEST_CASE("test_info_basics")
 
     std::cout << info.Get<int>("echo_level") << std::endl << std::endl;
 
-    // REQUIRE(info.Get<int>("echo_level") == 1); // not working
+    REQUIRE(info.Get<int>("echo_level") == 1); // not working
 }
 
 TEST_CASE("test_info_local_vars")
@@ -53,7 +53,7 @@ TEST_CASE("test_info_local_vars")
 
     REQUIRE(info.Has("local_var_int"));
 
-    // REQUIRE(info.Get<int>("local_var_int") == 15); // not working
+    REQUIRE(info.Get<int>("local_var_int") == 15); // not working
 }
 
 } // namespace CoSimIO

--- a/tests/co_sim_io/internals/test_info.cpp
+++ b/tests/co_sim_io/internals/test_info.cpp
@@ -16,7 +16,7 @@
 
 namespace CoSimIO {
 
-TEST_CASE("test_info_int")
+TEST_CASE("test_info_basics_int")
 {
     Info info;
 
@@ -29,7 +29,7 @@ TEST_CASE("test_info_int")
     REQUIRE(info.Get<int>("echo_level") == 1);
 }
 
-TEST_CASE("test_info_double")
+TEST_CASE("test_info_basics_double")
 {
     Info info;
 
@@ -42,7 +42,7 @@ TEST_CASE("test_info_double")
     REQUIRE(info.Get<double>("tolerance") == Approx(1.5));
 }
 
-TEST_CASE("test_info_bool")
+TEST_CASE("test_info_basics_bool")
 {
     Info info;
 
@@ -55,7 +55,7 @@ TEST_CASE("test_info_bool")
     REQUIRE(info.Get<bool>("print_sth") == false);
 }
 
-TEST_CASE("test_info_string")
+TEST_CASE("test_info_basics_string")
 {
     Info info;
 
@@ -66,6 +66,18 @@ TEST_CASE("test_info_string")
     REQUIRE(info.Has("identifier"));
 
     REQUIRE(info.Get<std::string>("identifier") == "pressure");
+}
+
+TEST_CASE("test_info_wrong_type")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("identifier"));
+
+    info.Set<std::string>("identifier", "pressure");
+
+    REQUIRE(info.Has("identifier"));
+    REQUIRE_THROWS_WITH(info.Get<int>("identifier"), "std::exception"); // TODO find a better way of testing this
 }
 
 TEST_CASE("test_info_many_values")
@@ -91,6 +103,85 @@ TEST_CASE("test_info_many_values")
     REQUIRE(info.Get<bool>("is_converged") == true);
     REQUIRE(info.Get<double>("tol") == Approx(0.008));
     REQUIRE(info.Get<int>("echo_level") == 2);
+}
+
+TEST_CASE("test_info_set_alreay_existing")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("identifier"));
+    info.Set<std::string>("identifier", "velocity_interface");
+    REQUIRE(info.Has("identifier"));
+    REQUIRE(info.Get<std::string>("identifier") == "velocity_interface");
+
+    // now overwriting the already existing value
+    info.Set<std::string>("identifier", "pressure");
+    REQUIRE(info.Get<std::string>("identifier") == "pressure");
+}
+
+TEST_CASE("test_info_set_alreay_existing_different_data_type")
+{
+    Info info;
+
+    REQUIRE_FALSE(info.Has("identifier"));
+    info.Set<std::string>("identifier", "velocity_interface");
+    REQUIRE(info.Has("identifier"));
+    REQUIRE(info.Get<std::string>("identifier") == "velocity_interface");
+
+    // now overwriting the already existing value with a different type
+    info.Set<int>("identifier", 15);
+    REQUIRE(info.Get<int>("identifier") == 15);
+}
+
+TEST_CASE("test_info_size")
+{
+    Info info;
+    REQUIRE(info.Size() == 0);
+
+    info.Set<std::string>("identifier", "velocity_interface");
+    info.Set<bool>("is_converged", true);
+    info.Set<double>("tol", 0.008);
+    info.Set<int>("echo_level", 2);
+
+    REQUIRE(info.Size() == 4);
+    info.Set<int>("echo_level", 6);
+    REQUIRE(info.Size() == 4);
+}
+
+TEST_CASE("test_info_clear")
+{
+    Info info;
+    REQUIRE(info.Size() == 0);
+
+    info.Set<std::string>("identifier", "velocity_interface");
+    info.Set<bool>("is_converged", true);
+    info.Set<double>("tol", 0.008);
+    info.Set<int>("echo_level", 2);
+
+    REQUIRE(info.Size() == 4);
+    info.Set<int>("echo_level", 6);
+    REQUIRE(info.Size() == 4);
+
+    info.Clear();
+    REQUIRE(info.Size() == 0);
+}
+
+TEST_CASE("test_info_erase")
+{
+    Info info;
+    REQUIRE(info.Size() == 0);
+
+    info.Set<std::string>("identifier", "velocity_interface");
+    REQUIRE(info.Has("identifier"));
+    REQUIRE(info.Size() == 1);
+
+    info.Erase("identifier");
+    REQUIRE_FALSE(info.Has("identifier"));
+    REQUIRE(info.Size() == 0);
+
+    // erasing non-existing keys does not throw
+    REQUIRE_NOTHROW(info.Erase("identifier"));
+    REQUIRE_NOTHROW(info.Erase("whatever"));
 }
 
 } // namespace CoSimIO

--- a/tests/co_sim_io/internals/test_info.cpp
+++ b/tests/co_sim_io/internals/test_info.cpp
@@ -20,6 +20,8 @@ namespace {
 
 void AddLocalInt(Info& rInfo)
 {
+    // this puts a local variable into the info
+    // it should still giv the correct result even after the local var goes out of scope
     int local_var = 15;
     REQUIRE_FALSE(rInfo.Has("local_var_int"));
 


### PR DESCRIPTION
@pooyan-dadvand I think we need sth more elaborate for the memory-management if the `Info` object.
Not saving the memory but only the pointer messes things up
https://github.com/KratosMultiphysics/CoSimIO/blob/master/co_sim_io/impl/info.hpp#L30-L78

I don't fully understand how this works in Kratos (too many `Variable...` classes :) )
Can you pleas have a look?

