### PR TITLE
Add version

### DIFF
--- a/co_sim_io/impl/co_sim_io_impl.hpp
+++ b/co_sim_io/impl/co_sim_io_impl.hpp
@@ -58,15 +58,15 @@ inline ReturnInfo Hello()
     std::cout << "The detached interface for coupled simulations together with the\n";
     std::cout << "CoSimulationApplication of KratosMultiphysics\n\"https://github.com/KratosMultiphysics/Kratos/tree/master/applications/CoSimulationApplication\"\n";
     std::cout << "Version:\n";
-    std::cout << "    Major: " << Internals::GetMajorVersion() << "\n";
-    std::cout << "    Minor: " << Internals::GetMinorVersion() << "\n";
-    std::cout << "    Patch: " << Internals::GetPatchVersion() << "\n";
+    std::cout << "    Major: " << GetMajorVersion() << "\n";
+    std::cout << "    Minor: " << GetMinorVersion() << "\n";
+    std::cout << "    Patch: " << GetPatchVersion() << "\n";
     std::cout << "For more information please visit \"https://github.com/KratosMultiphysics/CoSimIO\"" << std::endl;
 
     ReturnInfo ret_info;
-    ret_info.Set("major_version", Internals::GetMajorVersion());
-    ret_info.Set("minor_version", Internals::GetMinorVersion());
-    ret_info.Set("patch_version", Internals::GetPatchVersion());
+    ret_info.Set("major_version", GetMajorVersion());
+    ret_info.Set("minor_version", GetMinorVersion());
+    ret_info.Set("patch_version", GetPatchVersion());
     // TODO maybe add more things too here
 
     return ret_info;

--- a/co_sim_io/impl/co_sim_io_impl.hpp
+++ b/co_sim_io/impl/co_sim_io_impl.hpp
@@ -66,7 +66,7 @@ inline ReturnInfo Hello()
     ReturnInfo ret_info;
     ret_info.Set("major_version", Internals::GetMajorVersion());
     ret_info.Set("minor_version", Internals::GetMinorVersion());
-    ret_info.Set("minor_version", Internals::GetPatchVersion());
+    ret_info.Set("patch_version", Internals::GetPatchVersion());
     // TODO maybe add more things too here
 
     return ret_info;

--- a/co_sim_io/impl/co_sim_io_impl.hpp
+++ b/co_sim_io/impl/co_sim_io_impl.hpp
@@ -23,6 +23,7 @@ This file contains the implementation of the functions defined in "co_sim_io.hpp
 
 // Project includes
 #include "connection.hpp"
+#include "version.hpp"
 
 namespace CoSimIO {
 
@@ -57,14 +58,18 @@ inline ReturnInfo Hello()
     std::cout << "The detached interface for coupled simulations together with the\n";
     std::cout << "CoSimulationApplication of KratosMultiphysics\n\"https://github.com/KratosMultiphysics/Kratos/tree/master/applications/CoSimulationApplication\"\n";
     std::cout << "Version:\n";
-    std::cout << "    Major: " << 1 << "\n";
-    std::cout << "    Minor: " << 0 << "\n";
-    std::cout << "    Patch: " << "xxx\n";
+    std::cout << "    Major: " << Internals::GetMajorVersion() << "\n";
+    std::cout << "    Minor: " << Internals::GetMinorVersion() << "\n";
+    std::cout << "    Patch: " << Internals::GetPatchVersion() << "\n";
     std::cout << "For more information please visit \"https://github.com/KratosMultiphysics/CoSimIO\"" << std::endl;
 
-    // TODO return version and other things in ReturnInfo
+    ReturnInfo ret_info;
+    ret_info.Set("major_version", Internals::GetMajorVersion());
+    ret_info.Set("minor_version", Internals::GetMinorVersion());
+    ret_info.Set("minor_version", Internals::GetPatchVersion());
+    // TODO maybe add more things too here
 
-    return ReturnInfo(); // TODO use this
+    return ret_info;
 }
 
 

--- a/co_sim_io/impl/info.hpp
+++ b/co_sim_io/impl/info.hpp
@@ -162,6 +162,8 @@ private:
     #ifdef CO_SIM_IO_USING_MPI
     MPI_Comm mMpiComm = nullptr;
     #endif // CO_SIM_IO_USING_MPI
+
+    // TODO add version of Solver
 };
 
 

--- a/co_sim_io/impl/version.hpp
+++ b/co_sim_io/impl/version.hpp
@@ -1,0 +1,3 @@
+major
+minor
+patch is commit hash

--- a/co_sim_io/impl/version.hpp
+++ b/co_sim_io/impl/version.hpp
@@ -17,7 +17,6 @@
 #include <string>
 
 namespace CoSimIO {
-namespace Internals {
 
 constexpr int GetMajorVersion() {
     return 1;
@@ -31,7 +30,6 @@ std::string GetPatchVersion() {
     return "xxx";
 }
 
-} // namespace Internals
 } // namespace CoSimIO
 
 #endif // CO_SIM_IO_VERSION_H_INCLUDED

--- a/co_sim_io/impl/version.hpp
+++ b/co_sim_io/impl/version.hpp
@@ -1,3 +1,37 @@
-major
-minor
-patch is commit hash
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef CO_SIM_IO_VERSION_H_INCLUDED
+#define CO_SIM_IO_VERSION_H_INCLUDED
+
+// System includes
+#include <string>
+
+namespace CoSimIO {
+namespace Internals {
+
+constexpr int GetMajorVersion() {
+    return 1;
+}
+
+constexpr int GetMinorVersion() {
+    return 0;
+}
+
+std::string GetPatchVersion() {
+    return "xxx";
+}
+
+} // namespace Internals
+} // namespace CoSimIO
+
+#endif // CO_SIM_IO_VERSION_H_INCLUDED


### PR DESCRIPTION
This adds the Version, pretty similar to how it is done in Kratos
two questions:
- would you prefer to have this more accessible? I.e. in the `CoSimIO` namespace and not in the `CoSimIO::Internals` namespace?
- would you prefer to have the version as `#define` like it is done in Kratos?

Only thing I am not sure yet is how to generate the hash yet (bcs it is header-only), but this can most likely be done by an actions after every merge
I would not do this atm, IMO it is not that important for now