### PR TITLE
Adding cpp ctests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ message("    BUILD_PYTHON:   " ${BUILD_PYTHON})
 message("    BUILD_FORTRAN:  " ${BUILD_FORTRAN})
 message("")
 
+enable_testing()
+
 if(MSVC)
     # required such that "__cplusplus" is set to the correct value
     # see https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,9 +17,9 @@ message("    BUILD_PYTHON:   " ${BUILD_PYTHON})
 message("    BUILD_FORTRAN:  " ${BUILD_FORTRAN})
 message("")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-
 enable_testing()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 if(MSVC)
     # required such that "__cplusplus" is set to the correct value

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,21 @@ set_target_properties(test_runner_cpp PROPERTIES
     CXX_EXTENSIONS NO
 )
 
+function(add_cpp_test TEST_SOURCE_FILE)
+    get_filename_component(TEST_FILENAME ${TEST_SOURCE_FILE} NAME)
+    string(REGEX REPLACE ".cpp" "_cpp_test" TEST_NAME ${TEST_FILENAME})
+    message(STATUS  "adding ${TEST_NAME} ")
+    add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
+    add_test(${TEST_NAME} ${TEST_NAME})
+    install(TARGETS ${TEST_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/bin")
+endfunction()
+
+file(GLOB cpp_test_files "solver_integration/cpp_solver/*.cpp")
+
+foreach(cpp_test_file ${cpp_test_files})
+  add_cpp_test(${cpp_test_file})
+endforeach(cpp_test_file)
+
 
 ### C tests ###
 if(BUILD_C)

--- a/tests/solver_integration/cpp_solver/hello.cpp
+++ b/tests/solver_integration/cpp_solver/hello.cpp
@@ -1,0 +1,26 @@
+// CoSimulation includes
+#include "co_sim_io.hpp"
+
+// move this macro to a checks.hpp in tests folder?
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a   \
+                  << " is not equal to " << b << std::endl; \
+        return 1;                                                \
+    }
+    
+int main(){
+    auto info = CoSimIO::Hello();
+
+    std::cout << info << std::endl;
+
+    int major_version = info.Get<int>("major_version");
+    int minor_version = info.Get<int>("minor_version");
+    std::string patch_version = info.Get<std::string>("patch_version");
+
+    COSIMIO_CHECK_EQUAL(major_version, 0);
+    COSIMIO_CHECK_EQUAL(minor_version, 0);
+
+
+    return 0;
+}

--- a/tests/solver_integration/cpp_solver/hello.cpp
+++ b/tests/solver_integration/cpp_solver/hello.cpp
@@ -1,3 +1,15 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+
 // CoSimulation includes
 #include "co_sim_io.hpp"
 
@@ -9,7 +21,8 @@
         return 1;                                                \
     }
     
-int main(){
+int main()
+{
     auto info = CoSimIO::Hello();
 
     std::cout << info << std::endl;
@@ -20,7 +33,6 @@ int main(){
 
     COSIMIO_CHECK_EQUAL(major_version, 0);
     COSIMIO_CHECK_EQUAL(minor_version, 0);
-
 
     return 0;
 }


### PR DESCRIPTION
This will automatically detect any cpp in the cpp_solver folder. Using the ctest botton in the Code status bar restuls in:

```
[proc] Executing command: /usr/bin/ctest -j34 -C Debug -T test --output-on-failure
[ctest] Cannot find file: /home/pooyan/Developments/CoSimIO/build/DartConfiguration.tcl
[ctest] Cannot find file: /home/pooyan/Developments/CoSimIO/build/DartConfiguration.tcl
[ctest]    Site: 
[ctest]    Build name: (empty)
[ctest] Test project /home/pooyan/Developments/CoSimIO/build
[ctest]     Start 1: hello_cpp_test
[ctest] 1/1 Test #1: hello_cpp_test ...................   Passed    0.01 sec
[ctest] 
[ctest] 100% tests passed, 0 tests failed out of 1
[ctest] 
[ctest] Total Test time (real) =   0.01 sec
[ctest] CTest finished with return code 0
```