### PR TITLE
override only for gcc > 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ if(MSVC)
 
     set( CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON )
 elseif(${CMAKE_COMPILER_IS_GNUCXX})
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wsuggest-override -Wignored-qualifiers")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
+    if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override -Wignored-qualifiers")
+    endif()
 else() # assumed to be CLANG
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall")
 endif()


### PR DESCRIPTION
now works the same as in Kratos