### PR TITLE
adding Werror to C-flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,8 @@ jobs:
           -DBUILD_C=ON               \
           -DBUILD_PYTHON=ON          \
           -DBUILD_FORTRAN=OFF        \
-          -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Werror"
+          -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -Werror" \
+          -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -Werror"
 
         cmake --build "build" --target install
 

--- a/tests/integration_tutorials/c/export_import_data.c
+++ b/tests/integration_tutorials/c/export_import_data.c
@@ -13,9 +13,15 @@
 // CoSimulation includes
 #include "c/co_sim_io_c.h"
 
-#define COSIMIO_CHECK_EQUAL(a, b)                                \
+#define COSIMIO_CHECK_EQUAL_INT(a, b)                            \
     if (a != b) {                                                \
         printf("in line %d : %d is not equalt to %d\n", __LINE__ , a, b); \
+        return 1;                                                \
+    }
+
+#define COSIMIO_CHECK_EQUAL_DOUBLE(a, b)                         \
+    if (a != b) {                                                \
+        printf("in line %d : %f is not equalt to %f\n", __LINE__ , a, b); \
         return 1;                                                \
     }
 
@@ -30,14 +36,14 @@ int main()
 
     // Connecting using the connection settings
     CoSimIO_Info connect_info = CoSimIO_Connect(connection_settings);
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
-    CoSimIO_FreeInfo(connect_info); // Don't forget to free the connect_info 
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
+    CoSimIO_FreeInfo(connect_info); // Don't forget to free the connect_info
 
     // After conneting we may export the data
     int data_size = 4;
     double data_to_send[] = {3, .1, .14, 3.14};
 
-    // Creatint the export_settings 
+    // Creatint the export_settings
     CoSimIO_Info export_settings=CoSimIO_CreateInfo();
     CoSimIO_Info_SetString(export_settings, "identifier", "data_exchange_1");
     CoSimIO_Info_SetString(export_settings, "connection_name", "im_exp_data");
@@ -45,7 +51,7 @@ int main()
     // Exporting the data
     CoSimIO_Info export_info = CoSimIO_ExportData(export_settings, data_size, data_to_send);
     // Freeing the export_info and export_settings
-    CoSimIO_FreeInfo(export_info); 
+    CoSimIO_FreeInfo(export_info);
     CoSimIO_FreeInfo(export_settings);
 
 
@@ -65,12 +71,12 @@ int main()
     CoSimIO_FreeInfo(import_settings);
 
     for(int i = 0 ; i < data_size ; i++)
-        COSIMIO_CHECK_EQUAL(data_to_send[i], data[i]);
+        COSIMIO_CHECK_EQUAL_DOUBLE(data_to_send[i], data[i]);
 
 
     // Disconnecting at the end
     CoSimIO_Info disconnect_info = CoSimIO_Disconnect(connection_settings); // disconnect afterwards
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
 
     // Don't forget to release the settings and info
     CoSimIO_FreeInfo(connection_settings);

--- a/tests/integration_tutorials/c/export_import_mesh.c
+++ b/tests/integration_tutorials/c/export_import_mesh.c
@@ -13,9 +13,15 @@
 // CoSimulation includes
 #include "c/co_sim_io_c.h"
 
-#define COSIMIO_CHECK_EQUAL(a, b)                                \
+#define COSIMIO_CHECK_EQUAL_INT(a, b)                            \
     if (a != b) {                                                \
         printf("in line %d : %d is not equalt to %d\n", __LINE__ , a, b); \
+        return 1;                                                \
+    }
+
+#define COSIMIO_CHECK_EQUAL_DOUBLE(a, b)                         \
+    if (a != b) {                                                \
+        printf("in line %d : %f is not equalt to %f\n", __LINE__ , a, b); \
         return 1;                                                \
     }
 
@@ -30,7 +36,7 @@ int main()
 
     // Connecting using the connection settings
     CoSimIO_Info connect_info = CoSimIO_Connect(connection_settings);
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
     CoSimIO_FreeInfo(connect_info); // Don't forget to free the connect_info
 
     int export_number_of_nodes=6;
@@ -90,22 +96,22 @@ int main()
     CoSimIO_FreeInfo(import_info);
     CoSimIO_FreeInfo(import_settings);
 
-    COSIMIO_CHECK_EQUAL(export_number_of_nodes, import_number_of_nodes);
-    COSIMIO_CHECK_EQUAL(export_number_of_elements_connectivities, import_number_of_elements_connectivities);
-    COSIMIO_CHECK_EQUAL(export_number_of_elements, import_number_of_elements);
+    COSIMIO_CHECK_EQUAL_INT(export_number_of_nodes, import_number_of_nodes);
+    COSIMIO_CHECK_EQUAL_INT(export_number_of_elements_connectivities, import_number_of_elements_connectivities);
+    COSIMIO_CHECK_EQUAL_INT(export_number_of_elements, import_number_of_elements);
 
     for(int i = 0 ; i < import_number_of_nodes * 3 ; i++)
-        COSIMIO_CHECK_EQUAL(export_nodal_coordinates[i], import_nodal_coordinates[i]);
+        COSIMIO_CHECK_EQUAL_DOUBLE(export_nodal_coordinates[i], import_nodal_coordinates[i]);
 
     for(int i = 0 ; i < import_number_of_elements_connectivities ; i++)
-        COSIMIO_CHECK_EQUAL(export_elements_connectivities[i], import_elements_connectivities[i]);
+        COSIMIO_CHECK_EQUAL_INT(export_elements_connectivities[i], import_elements_connectivities[i]);
 
     for(int i = 0 ; i < import_number_of_elements ; i++)
-        COSIMIO_CHECK_EQUAL(export_elements_types[i], import_elements_types[i]);
+        COSIMIO_CHECK_EQUAL_INT(export_elements_types[i], import_elements_types[i]);
 
     // Disconnecting at the end
     CoSimIO_Info disconnect_info = CoSimIO_Disconnect(connection_settings); // disconnect afterwards
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
 
     // Don't forget to release the settings and info
     CoSimIO_FreeInfo(connection_settings);

--- a/tests/integration_tutorials/c/import_mesh.c
+++ b/tests/integration_tutorials/c/import_mesh.c
@@ -13,9 +13,15 @@
 // CoSimulation includes
 #include "c/co_sim_io_c.h"
 
-#define COSIMIO_CHECK_EQUAL(a, b)                                \
+#define COSIMIO_CHECK_EQUAL_INT(a, b)                            \
     if (a != b) {                                                \
         printf("in line %d : %d is not equalt to %d\n", __LINE__ , a, b); \
+        return 1;                                                \
+    }
+
+#define COSIMIO_CHECK_EQUAL_DOUBLE(a, b)                         \
+    if (a != b) {                                                \
+        printf("in line %d : %f is not equalt to %f\n", __LINE__ , a, b); \
         return 1;                                                \
     }
 
@@ -30,7 +36,7 @@ int main()
 
     // Connecting using the connection settings
     CoSimIO_Info connect_info = CoSimIO_Connect(connection_settings);
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(connect_info, "connection_status"), CoSimIO_Connected);
     CoSimIO_FreeInfo(connect_info); // Don't forget to free the connect_info
 
     // After conneting we may import the mesh
@@ -77,23 +83,23 @@ int main()
     int expected_number_of_elements = 4;
     int expected_elements_types[] = {5,5,5,5}; // VTK_TRIANGLE
 
-    COSIMIO_CHECK_EQUAL(expected_number_of_nodes,  number_of_nodes);
-    COSIMIO_CHECK_EQUAL(expected_number_of_elements_connectivities,  number_of_elements_connectivities);
-    COSIMIO_CHECK_EQUAL(expected_number_of_elements,  number_of_elements);
+    COSIMIO_CHECK_EQUAL_INT(expected_number_of_nodes,  number_of_nodes);
+    COSIMIO_CHECK_EQUAL_INT(expected_number_of_elements_connectivities,  number_of_elements_connectivities);
+    COSIMIO_CHECK_EQUAL_INT(expected_number_of_elements,  number_of_elements);
 
     for(int i = 0 ; i <  number_of_nodes * 3 ; i++)
-        COSIMIO_CHECK_EQUAL(expected_nodal_coordinates[i],  nodal_coordinates[i]);
+        COSIMIO_CHECK_EQUAL_DOUBLE(expected_nodal_coordinates[i],  nodal_coordinates[i]);
 
     for(int i = 0 ; i <  number_of_elements_connectivities ; i++)
-        COSIMIO_CHECK_EQUAL(expected_elements_connectivities[i],  elements_connectivities[i]);
+        COSIMIO_CHECK_EQUAL_INT(expected_elements_connectivities[i],  elements_connectivities[i]);
 
     for(int i = 0 ; i <  number_of_elements ; i++)
-        COSIMIO_CHECK_EQUAL(expected_elements_types[i],  elements_types[i]);
+        COSIMIO_CHECK_EQUAL_INT(expected_elements_types[i],  elements_types[i]);
 
 
     // Disconnecting at the end
     CoSimIO_Info disconnect_info = CoSimIO_Disconnect(connection_settings); // disconnect afterwards
-    COSIMIO_CHECK_EQUAL(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
+    COSIMIO_CHECK_EQUAL_INT(CoSimIO_Info_GetInt(disconnect_info, "connection_status"), CoSimIO_Disconnected);
 
     // Don't forget to release the settings and info
     CoSimIO_FreeInfo(connection_settings);


### PR DESCRIPTION
currently only in C++ the warnings are turned into errors.
This PR does the same for C

=> this will need fixes in some `printf` functions