### PR TITLE
Missing inline and test

### DIFF
--- a/co_sim_io/impl/version.hpp
+++ b/co_sim_io/impl/version.hpp
@@ -26,7 +26,7 @@ constexpr int GetMinorVersion() {
     return 0;
 }
 
-std::string GetPatchVersion() {
+inline std::string GetPatchVersion() {
     return "0";
 }
 

--- a/tests/co_sim_io/impl/test_include_co_sim_io_1.cpp
+++ b/tests/co_sim_io/impl/test_include_co_sim_io_1.cpp
@@ -1,0 +1,19 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+/* this file makes sure that the CoSimIO can be safely included in different cpp files
+i.e. it ensures that all the functions are inlined otherwise linking errors occur
+the "other" file that includes CoSimIO is "test_include_co_sim_io_2.cpp"
+*/
+
+// Project includes
+#include "co_sim_io.hpp"

--- a/tests/co_sim_io/impl/test_include_co_sim_io_2.cpp
+++ b/tests/co_sim_io/impl/test_include_co_sim_io_2.cpp
@@ -1,0 +1,17 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+/* see "test_include_co_sim_io_1.cpp" for why this file is necessary
+*/
+
+// Project includes
+#include "co_sim_io.hpp"


### PR DESCRIPTION
@pooyan-dadvand looks like we forgot an inline :D

In any case now I added a test such that we are sure `co_sim_io.hpp` can be safely included in multiple source files