### PR TITLE
bringing back C tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -70,9 +70,9 @@ if(BUILD_C)
     endforeach(c_integration_test_file)
 
     add_test(hello_c_test hello_c_test)
-    # add_test(NAME connect_disconnect_c_test COMMAND bash run.sh $<TARGET_FILE:connect_disconnect_c_test>  $<TARGET_FILE:connect_disconnect_c_test>)
-    # add_test(NAME import_export_data_c_test COMMAND bash run.sh $<TARGET_FILE:export_data_c_test>  $<TARGET_FILE:import_data_c_test>)
-    # add_test(NAME import_export_mesh_c_test COMMAND bash run.sh $<TARGET_FILE:export_mesh_c_test>  $<TARGET_FILE:import_mesh_c_test>)
+    add_test(NAME connect_disconnect_c_test COMMAND bash run.sh $<TARGET_FILE:connect_disconnect_c_test>  $<TARGET_FILE:connect_disconnect_c_test>)
+    add_test(NAME import_export_data_c_test COMMAND bash run.sh $<TARGET_FILE:export_data_c_test>  $<TARGET_FILE:import_data_c_test>)
+    add_test(NAME import_export_mesh_c_test COMMAND bash run.sh $<TARGET_FILE:export_mesh_c_test>  $<TARGET_FILE:import_mesh_c_test>)
 endif()
 
 


### PR DESCRIPTION
I noticed that some C tests were commented (see [here](https://github.com/KratosMultiphysics/CoSimIO/pull/56/commits/57067c00f37c1f2ba62ec106d3eb8088a7c7a72a))
They give memory errors, but to me it seems like those come from `bash` and not from us. Not sure why the same tests in cpp work, at least there valgrind doesn't give an error

Probably we need to suppress the warnings of `bash` => solving this issue somehow is already on the todo list: https://github.com/KratosMultiphysics/CoSimIO/issues/55