### PR TITLE
fixing check macros by "hiding" counters

### DIFF
--- a/tests/co_sim_io/impl/co_sim_io_testing.hpp
+++ b/tests/co_sim_io/impl/co_sim_io_testing.hpp
@@ -15,19 +15,19 @@
 
 // Custom macros
 
-#define CO_SIM_IO_CHECK_VECTOR_NEAR(a, b) {     \
-REQUIRE_EQ(a.size(), b.size());                 \
-for (std::size_t i=0; i<a.size(); ++i) {        \
-   CHECK_MESSAGE(a[i] == doctest::Approx(b[i]), \
-   "Mismatch in component: " << i);             \
-}                                               \
+#define CO_SIM_IO_CHECK_VECTOR_NEAR(a, b) {       \
+REQUIRE_EQ(a.size(), b.size());                   \
+for (std::size_t _i=0; _i<a.size(); ++_i) {       \
+   CHECK_MESSAGE(a[_i] == doctest::Approx(b[_i]), \
+   "Mismatch in component: " << _i);              \
+}                                                 \
 }
 
 #define CO_SIM_IO_CHECK_VECTOR_NEAR_SIZE(a, b, s) { \
 REQUIRE_GE(a.size(), s);                            \
 REQUIRE_GE(b.size(), s);                            \
-for (std::size_t i=0; i<s; ++i) {                   \
-   CHECK_MESSAGE(a[i] == doctest::Approx(b[i]),     \
-   "Mismatch in component: " << i);                 \
+for (std::size_t _i=0; _i<s; ++_i) {                \
+   CHECK_MESSAGE(a[_i] == doctest::Approx(b[_i]),   \
+   "Mismatch in component: " << _i);                \
 }                                                   \
 }


### PR DESCRIPTION
FYI @pooyan-dadvand when using this Macro in a loop that has the same counter variable (`i` in my case) this was not working, after the macro unrolling it was using the same variable :facepalm: 

@roigcarlo [Kratos has the same issue,](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/checks.h#L58-L153) just that apparently it wasn't detected there yet