### PR TITLE
ModelPart proper element types

### DIFF
--- a/co_sim_io/impl/define.hpp
+++ b/co_sim_io/impl/define.hpp
@@ -55,6 +55,17 @@ enum ConnectionStatus
     DisconnectionError
 };
 
+// see https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf ; figure 2
+enum ElementType
+{
+    VERTEX     = 1,
+    LINE       = 3,
+    TRIANGLE   = 5,
+    QUAD       = 9,
+    TETRA      = 10,
+    HEXAHEDRON = 12
+};
+
 // Note: std::make_unique is C++14, this can be updated once we upgrade from C++11
 template<typename C, typename...Args>
 std::unique_ptr<C> make_unique(Args &&...args) {

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -30,8 +30,10 @@ see https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/mod
 // Project includes
 #include "define.hpp"
 #include "macros.hpp"
+#include "utilities.hpp"
 
 namespace CoSimIO {
+
 class Node
 {
 public:
@@ -103,6 +105,8 @@ public:
     {
         CO_SIM_IO_ERROR_IF(I_Id < 1) << "Id must be >= 1!" << std::endl;
         CO_SIM_IO_ERROR_IF(NumberOfNodes() < 1) << "No nodes were passed!" << std::endl;
+        const int num_nodes_elem_type = CoSimIO::Internals::GetNumberOfNodesForElementType(I_Type);
+        CO_SIM_IO_ERROR_IF_NOT(num_nodes_elem_type == static_cast<int>(NumberOfNodes())) << "Number of nodes (" << NumberOfNodes() << ") does not match expected number for element type (" << num_nodes_elem_type << ")!" << std::endl;
     }
 
     // delete copy and assignment CTor
@@ -143,6 +147,7 @@ inline std::ostream & operator <<(
     rThis.Print(rOStream);
     return rOStream;
 }
+
 
 class ModelPart
 {

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -90,7 +90,6 @@ inline std::ostream & operator <<(
 class Element
 {
 public:
-    using ElementType = std::size_t;
     using NodesContainerType = std::vector<Node*>;
     using ConnectivitiesType = std::vector<IdType>;
 
@@ -182,7 +181,7 @@ public:
 
     Element& CreateNewElement(
         const IdType I_Id,
-        const Element::ElementType I_Type,
+        const ElementType I_Type,
         const Element::ConnectivitiesType& I_Connectivities)
     {
         CO_SIM_IO_ERROR_IF(HasElement(I_Id)) << "The Element with Id " << I_Id << " exists already!" << std::endl;

--- a/co_sim_io/impl/utilities.hpp
+++ b/co_sim_io/impl/utilities.hpp
@@ -15,7 +15,7 @@
 
 // System includes
 #include <string>
-#include <unordered_map>
+#include <map>
 
 // Project includes
 #include "define.hpp"
@@ -39,7 +39,7 @@ inline std::string CreateConnectionName(
 
 inline int GetNumberOfNodesForElementType(ElementType Type)
 {
-    const std::unordered_map<ElementType, int> vtk_cell_type_map {
+    const std::map<ElementType, int> vtk_cell_type_map {
         { ElementType::VERTEX,     1},
         { ElementType::LINE,       2},
         { ElementType::TRIANGLE,   3},

--- a/co_sim_io/impl/utilities.hpp
+++ b/co_sim_io/impl/utilities.hpp
@@ -15,6 +15,10 @@
 
 // System includes
 #include <string>
+#include <unordered_map>
+
+// Project includes
+#include "define.hpp"
 
 namespace CoSimIO {
 namespace Internals {
@@ -31,6 +35,22 @@ inline std::string CreateConnectionName(
     } else {
         return rName2 + "_" + rName1;
     }
+}
+
+inline int GetNumberOfNodesForElementType(ElementType Type)
+{
+    const std::unordered_map<ElementType, int> vtk_cell_type_map {
+        { ElementType::VERTEX,     1},
+        { ElementType::LINE,       2},
+        { ElementType::TRIANGLE,   3},
+        { ElementType::QUAD,       4},
+        { ElementType::TETRA,      4},
+        { ElementType::HEXAHEDRON, 8}
+    };
+
+    auto type_iter = vtk_cell_type_map.find(Type);
+    CO_SIM_IO_ERROR_IF(type_iter == vtk_cell_type_map.end()) << "Unsupported cell type: " << Type << std::endl;
+    return type_iter->second;
 }
 
 } // namespace Internals

--- a/co_sim_io/python/model_part_to_python.hpp
+++ b/co_sim_io/python/model_part_to_python.hpp
@@ -43,7 +43,7 @@ void AddCoSimIOModelPartToPython(pybind11::module& m)
         ;
 
     py::class_<CoSimIO::Element, CoSimIO::ModelPart::ElementPointerType>(m,"Element")
-        .def(py::init<const CoSimIO::IdType, const CoSimIO::Element::ElementType, const CoSimIO::Element::NodesContainerType&>())
+        .def(py::init<const CoSimIO::IdType, const CoSimIO::ElementType, const CoSimIO::Element::NodesContainerType&>())
         .def("Id", &CoSimIO::Element::Id)
         .def("Type", &CoSimIO::Element::Type)
         .def("NumberOfNodes", &CoSimIO::Element::NumberOfNodes)
@@ -73,6 +73,15 @@ void AddCoSimIOModelPartToPython(pybind11::module& m)
             }, py::keep_alive<0, 1>()) /* Keep vector alive while iterator is used */
         .def("__str__",   [](const CoSimIO::ModelPart& I_ModelPart)
             { std::stringstream ss; ss << I_ModelPart; return ss.str(); } )
+        ;
+
+    py::enum_<CoSimIO::ElementType>(m,"ElementType")
+        .value("VERTEX",     CoSimIO::ElementType::VERTEX)
+        .value("LINE",       CoSimIO::ElementType::LINE)
+        .value("TRIANGLE",   CoSimIO::ElementType::TRIANGLE)
+        .value("QUAD",       CoSimIO::ElementType::QUAD)
+        .value("TETRA",      CoSimIO::ElementType::TETRA)
+        .value("HEXAHEDRON", CoSimIO::ElementType::HEXAHEDRON)
         ;
 }
 

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -83,7 +83,7 @@ TEST_CASE("node_ostream")
 TEST_CASE("element_basics")
 {
     const int id = 33;
-    const std::size_t type = 5;
+    const CoSimIO::ElementType type = CoSimIO::ElementType::VERTEX;
 
     Node node(1, 0,0,0);
 
@@ -97,7 +97,7 @@ TEST_CASE("element_basics")
 TEST_CASE("element_checks")
 {
     const int id = -33;
-    const std::size_t type = 5;
+    const CoSimIO::ElementType type = CoSimIO::ElementType::VERTEX;
     Node node(1, 0,0,0);
 
     SUBCASE("negative_id")
@@ -114,7 +114,7 @@ TEST_CASE("element_checks")
 TEST_CASE("element_nodes")
 {
     const int id = 33;
-    const std::size_t type = 5;
+    const CoSimIO::ElementType type = CoSimIO::ElementType::TRIANGLE;
 
     const int node_ids[] = {2, 159, 61};
 
@@ -144,7 +144,7 @@ TEST_CASE("element_ostream")
     Node node_2(22, dummy_coords);
     Node node_3(321, dummy_coords);
 
-    Element element(65, 5, {&node_1, &node_2, &node_3});
+    Element element(65, CoSimIO::ElementType::TRIANGLE, {&node_1, &node_2, &node_3});
 
     std::stringstream test_stream;
 
@@ -272,7 +272,7 @@ TEST_CASE("model_part_create_new_element")
     CHECK_EQ(model_part.NumberOfNodes(), 1);
 
     const int elem_id = 47;
-    const std::size_t type = 5;
+    const CoSimIO::ElementType type = CoSimIO::ElementType::VERTEX;
 
     const auto& new_elem = model_part.CreateNewElement(elem_id, type, {node_id});
 
@@ -302,8 +302,12 @@ TEST_CASE("model_part_create_new_elements")
     CHECK_EQ(model_part.NumberOfNodes(), 3);
 
     const int elem_ids[] = {21, 19, 961};
-    const std::size_t elem_types[] = {5, 5, 9};
     const std::size_t elem_num_nodes[] = {1,1,2};
+    const CoSimIO::ElementType elem_types[] = {
+        CoSimIO::ElementType::VERTEX,
+        CoSimIO::ElementType::VERTEX,
+        CoSimIO::ElementType::LINE
+    };
 
     model_part.CreateNewElement(elem_ids[0], elem_types[0], {node_ids[0]});
     model_part.CreateNewElement(elem_ids[1], elem_types[1], {node_ids[1]});
@@ -325,10 +329,10 @@ TEST_CASE("model_part_create_new_element_twice")
     ModelPart model_part("for_test");
 
     model_part.CreateNewNode(1, 0,0,0);
-    model_part.CreateNewElement(1, 5, {1});
+    model_part.CreateNewElement(1, CoSimIO::ElementType::VERTEX, {1});
     REQUIRE_EQ(model_part.NumberOfElements(), 1);
 
-    CHECK_THROWS_WITH(model_part.CreateNewElement(1, 5, {1}), "Error: The Element with Id 1 exists already!\n");
+    CHECK_THROWS_WITH(model_part.CreateNewElement(1, CoSimIO::ElementType::VERTEX, {1}), "Error: The Element with Id 1 exists already!\n");
 }
 
 TEST_CASE("model_part_get_element")
@@ -338,7 +342,8 @@ TEST_CASE("model_part_get_element")
     model_part.CreateNewNode(1, 0,0,0);
 
     const int elem_id = 6;
-    model_part.CreateNewElement(elem_id, 5, {1});
+    const CoSimIO::ElementType type = CoSimIO::ElementType::VERTEX;
+    model_part.CreateNewElement(elem_id, type, {1});
     REQUIRE_EQ(model_part.NumberOfElements(), 1);
 
     SUBCASE("existing")
@@ -346,7 +351,7 @@ TEST_CASE("model_part_get_element")
         const auto& r_elem = model_part.GetElement(elem_id);
 
         CHECK_EQ(r_elem.Id(), elem_id);
-        CHECK_EQ(r_elem.Type(), 5);
+        CHECK_EQ(r_elem.Type(), type);
         CHECK_EQ(r_elem.NumberOfNodes(), 1);
     }
 
@@ -355,7 +360,7 @@ TEST_CASE("model_part_get_element")
         const auto p_elem = model_part.pGetElement(elem_id);
 
         CHECK_EQ(p_elem->Id(), elem_id);
-        CHECK_EQ(p_elem->Type(), 5);
+        CHECK_EQ(p_elem->Type(), type);
         CHECK_EQ(p_elem->NumberOfNodes(), 1);
     }
 
@@ -384,7 +389,7 @@ TEST_CASE("model_part_ostream")
         model_part.CreateNewNode(node_ids[1], node_coords[1], node_coords[2], node_coords[0]);
         model_part.CreateNewNode(node_ids[2], node_coords[2], node_coords[0], node_coords[1]);
 
-        model_part.CreateNewElement(15, 1, {node_ids[0]});
+        model_part.CreateNewElement(15, CoSimIO::ElementType::VERTEX, {node_ids[0]});
 
         exp_string = "CoSimIO-ModelPart \"for_test\"\n    Number of Nodes: 3\n    Number of Elements: 1\n";
     }

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -109,6 +109,11 @@ TEST_CASE("element_checks")
     {
         CHECK_THROWS_WITH(Element element(1, type, {}), "Error: No nodes were passed!\n");
     }
+
+    SUBCASE("wrong_element_type")
+    {
+        CHECK_THROWS_WITH(Element element(1, CoSimIO::ElementType::LINE, {&node}), "Error: Number of nodes (1) does not match expected number for element type (2)!\n");
+    }
 }
 
 TEST_CASE("element_nodes")

--- a/tests/co_sim_io/python/test_model_part.py
+++ b/tests/co_sim_io/python/test_model_part.py
@@ -54,7 +54,7 @@ class CoSimIO_ModelPart(unittest.TestCase):
 
     def test_element_basics(self):
         elem_id = 33
-        elem_type = 5
+        elem_type = CoSimIO.ElementType.VERTEX
 
         node = CoSimIO.Node(1, 0,0,0)
 
@@ -66,7 +66,7 @@ class CoSimIO_ModelPart(unittest.TestCase):
 
     def test_element_nodes(self):
         elem_id = 33
-        elem_type = 5
+        elem_type = CoSimIO.ElementType.TRIANGLE
 
         node_ids = [2, 159, 61]
 
@@ -91,7 +91,7 @@ class CoSimIO_ModelPart(unittest.TestCase):
         node_2 = CoSimIO.Node(22, dummy_coords)
         node_3 = CoSimIO.Node(321, dummy_coords)
 
-        element = CoSimIO.Element(65, 5, [node_1, node_2, node_3])
+        element = CoSimIO.Element(65, CoSimIO.ElementType.TRIANGLE, [node_1, node_2, node_3])
 
         exp_string = "CoSimIO-Element; Id: 65\n    Number of Nodes: 3\n    Node Ids: 1, 22, 321\n"
         self.assertMultiLineEqual(str(element), exp_string)
@@ -171,7 +171,7 @@ class CoSimIO_ModelPart(unittest.TestCase):
         self.assertEqual(model_part.NumberOfNodes(), 1)
 
         elem_id = 47
-        elem_type = 5
+        elem_type = CoSimIO.ElementType.VERTEX
 
         new_elem = model_part.CreateNewElement(elem_id, elem_type, [node_id])
 
@@ -196,7 +196,10 @@ class CoSimIO_ModelPart(unittest.TestCase):
         self.assertEqual(model_part.NumberOfNodes(), 3)
 
         elem_ids = [21, 19, 961]
-        elem_types = [5, 5, 9]
+        elem_types = [
+            CoSimIO.ElementType.VERTEX,
+            CoSimIO.ElementType.VERTEX,
+            CoSimIO.ElementType.LINE]
         elem_num_nodes = [1,1,2]
 
         model_part.CreateNewElement(elem_ids[0], elem_types[0], [node_ids[0]])
@@ -214,11 +217,11 @@ class CoSimIO_ModelPart(unittest.TestCase):
         model_part = CoSimIO.ModelPart("for_test")
 
         model_part.CreateNewNode(1, 0,0,0)
-        model_part.CreateNewElement(1, 5, [1])
+        model_part.CreateNewElement(1, CoSimIO.ElementType.VERTEX, [1])
         self.assertEqual(model_part.NumberOfElements(), 1)
 
         with self.assertRaisesRegex(Exception, 'Error: The Element with Id 1 exists already!'):
-            model_part.CreateNewElement(1, 5, [1])
+            model_part.CreateNewElement(1, CoSimIO.ElementType.VERTEX, [1])
 
     def test_model_part_get_element(self):
         model_part = CoSimIO.ModelPart("for_test")
@@ -226,13 +229,13 @@ class CoSimIO_ModelPart(unittest.TestCase):
         model_part.CreateNewNode(1, 0,0,0)
 
         elem_id = 6
-        model_part.CreateNewElement(elem_id, 5, [1])
+        model_part.CreateNewElement(elem_id, CoSimIO.ElementType.VERTEX, [1])
         self.assertEqual(model_part.NumberOfElements(), 1)
 
         with self.subTest("existing"):
             elem = model_part.GetElement(elem_id)
             self.assertEqual(elem.Id(), elem_id)
-            self.assertEqual(elem.Type(), 5)
+            self.assertEqual(elem.Type(), CoSimIO.ElementType.VERTEX)
             self.assertEqual(elem.NumberOfNodes(), 1)
 
         with self.subTest("non_existing"):
@@ -253,7 +256,7 @@ class CoSimIO_ModelPart(unittest.TestCase):
             model_part.CreateNewNode(node_ids[1], node_coords[1], node_coords[2], node_coords[0])
             model_part.CreateNewNode(node_ids[2], node_coords[2], node_coords[0], node_coords[1])
 
-            model_part.CreateNewElement(15, 1, [node_ids[0]])
+            model_part.CreateNewElement(15, CoSimIO.ElementType.VERTEX, [node_ids[0]])
 
             exp_string = "CoSimIO-ModelPart \"for_test\"\n    Number of Nodes: 3\n    Number of Elements: 1\n"
             self.assertMultiLineEqual(str(model_part), exp_string)

--- a/tests/co_sim_io/python/test_model_part.py
+++ b/tests/co_sim_io/python/test_model_part.py
@@ -42,7 +42,6 @@ class CoSimIO_ModelPart(unittest.TestCase):
             node = CoSimIO.Node(node_id, coords)
             Check(node)
 
-
     def test_print_node(self):
         coords = [1.0, -2.7, 9.44]
         node_id = 16


### PR DESCRIPTION
@pooyan-dadvand this PR improved the `ModelPart` to make the construction of Elements more clear.
Before one had to directly give the vtk cell number identifier (e.g. 5 for a triangle), now this can be explicitly specified. I like this much more, not sure why I haven't thought of it initially :)

Also now I can make sure the correct number of nodes is given for a specific geometry. I.e. now I can no longer use e.g. triangle and pass only 2 nodes in the construction of an element