### PR TITLE
removing old interfaces of I/E-Data

### DIFF
--- a/co_sim_io/impl/co_sim_io_impl.hpp
+++ b/co_sim_io/impl/co_sim_io_impl.hpp
@@ -102,11 +102,9 @@ inline Info ImportData(
     std::vector<double>& rData)
 {
     const std::string connection_name = I_Info.Get<std::string>("connection_name");
-    const std::string identifier = I_Info.Get<std::string>("identifier");
     using namespace CoSimIO::Internals;
     std::unique_ptr<DataContainer<double>> p_container(new DataContainerStdVector<double>(rData));
-    // TODO maybe pass the Info into the function (only changes under the hood necessary)
-    return GetConnection(connection_name).ImportData(identifier, *p_container);
+    return GetConnection(connection_name).ImportData(I_Info, *p_container);
 }
 
 // Version for C and fortran, there we already get a container
@@ -116,9 +114,7 @@ inline Info ImportData(
     CoSimIO::Internals::DataContainer<double>& rData)
 {
     const std::string connection_name = I_Info.Get<std::string>("connection_name");
-    const std::string identifier = I_Info.Get<std::string>("identifier");
-    // TODO maybe pass the Info into the function (only changes under the hood necessary)
-    return Internals::GetConnection(connection_name).ImportData(identifier, rData);
+    return Internals::GetConnection(connection_name).ImportData(I_Info, rData);
 }
 
 // Version for C++, there this input is a std::vector, which we have to wrap before passing it on
@@ -128,11 +124,9 @@ inline Info ExportData(
     const std::vector<double>& rData)
 {
     const std::string connection_name = I_Info.Get<std::string>("connection_name");
-    const std::string identifier = I_Info.Get<std::string>("identifier");
     using namespace CoSimIO::Internals;
     std::unique_ptr<DataContainer<double>> p_container(new DataContainerStdVectorReadOnly<double>(rData));
-    // TODO maybe pass the Info into the function (only changes under the hood necessary)
-    return GetConnection(connection_name).ExportData(identifier, *p_container);
+    return GetConnection(connection_name).ExportData(I_Info, *p_container);
 }
 
 // Version for C and fortran, there we already get a container
@@ -142,9 +136,7 @@ inline Info ExportData(
     const CoSimIO::Internals::DataContainer<double>& rData)
 {
     const std::string connection_name = I_Info.Get<std::string>("connection_name");
-    const std::string identifier = I_Info.Get<std::string>("identifier");
-    // TODO maybe pass the Info into the function (only changes under the hood necessary)
-    return Internals::GetConnection(connection_name).ExportData(identifier, rData);
+    return Internals::GetConnection(connection_name).ExportData(I_Info, rData);
 }
 
 template<>

--- a/co_sim_io/impl/communication/communication.hpp
+++ b/co_sim_io/impl/communication/communication.hpp
@@ -133,13 +133,13 @@ public:
     }
 
     template<class... Args>
-    Info ImportData_1X2(Args&&... args) // TODO fix name once other interface is removed
+    Info ImportData(Args&&... args)
     {
         CheckConnection(); return ImportDataImpl(std::forward<Args>(args)...);
     }
 
     template<class... Args>
-    Info ExportData_1X2(Args&&... args) // TODO fix name once other interface is removed
+    Info ExportData(Args&&... args)
     {
         CheckConnection(); return ExportDataImpl(std::forward<Args>(args)...);
     }
@@ -165,18 +165,6 @@ public:
     /*[[deprecated]]*/ CoSimIO::ControlSignal RecvControlSignal(std::string& rIdentifier)
     {
         CheckConnection(); return RecvControlSignalDetail(rIdentifier);
-    }
-
-    template<class... Args>
-    /*[[deprecated]]*/ void ImportData(Args&&... args)
-    {
-        CheckConnection(); ImportDataImpl(std::forward<Args>(args)...);
-    }
-
-    template<class... Args>
-    /*[[deprecated]]*/ void ExportData(Args&&... args)
-    {
-        CheckConnection(); ExportDataImpl(std::forward<Args>(args)...);
     }
 
     template<class... Args>
@@ -285,24 +273,6 @@ private:
     {
         CO_SIM_IO_ERROR << "RecvControlSignalDetail not implemented for this comm-type" << std::endl;
         return CoSimIO::ControlSignal::Dummy;
-    }
-
-    /*[[deprecated]]*/ void ImportDataImpl(
-        const std::string& rIdentifier,
-        CoSimIO::Internals::DataContainer<double>& rData)
-    {
-        Info tmp_info;
-        tmp_info.Set<std::string>("identifier", rIdentifier);
-        ImportDataImpl(tmp_info, rData);
-    }
-
-    /*[[deprecated]]*/ void ExportDataImpl(
-        const std::string& rIdentifier,
-        const CoSimIO::Internals::DataContainer<double>& rData)
-    {
-        Info tmp_info;
-        tmp_info.Set<std::string>("identifier", rIdentifier);
-        ExportDataImpl(tmp_info, rData);
     }
 
     virtual /*[[deprecated]]*/ void ImportMeshImpl(


### PR DESCRIPTION
One step in the direction of cleaning the interface
this time removing the old versions of `ImportData` and `ExportData`

FYI @pooyan-dadvand 