### PR TITLE
[Python] adding Vector

### DIFF
--- a/co_sim_io/python/co_sim_io_python.cpp
+++ b/co_sim_io/python/co_sim_io_python.cpp
@@ -28,6 +28,7 @@
 #include "../co_sim_io.hpp"
 #include "info_to_python.hpp"
 #include "model_part_to_python.hpp"
+#include "vector_to_python.hpp"
 #include "connection_status_to_python.hpp"
 #include "version_to_python.hpp"
 
@@ -126,6 +127,7 @@ PYBIND11_MODULE(CoSimIO, m)
 
     AddCoSimIOInfoToPython(m);
     AddCoSimIOModelPartToPython(m);
+    AddCoSimIOVectorToPython(m);
     AddCoSimIOConnectionStatusToPython(m);
     AddCoSimIOVersionToPython(m);
 }

--- a/co_sim_io/python/co_sim_io_python.cpp
+++ b/co_sim_io/python/co_sim_io_python.cpp
@@ -34,16 +34,6 @@
 
 namespace CoSimIO_Py_Wrappers {
 
-using ImportMeshReturnType = std::tuple<
-    CoSimIO::Info,
-    std::vector<double>,
-    std::vector<int>,
-    std::vector<int>>;
-
-using ImportDataReturnType = std::tuple<
-    CoSimIO::Info,
-    std::vector<double>>;
-
 CoSimIO::Info ImportMesh(
     const CoSimIO::Info& I_Info,
     CoSimIO::ModelPart& rModelPart)
@@ -60,27 +50,6 @@ CoSimIO::Info ExportMesh(
     return CoSimIO::ExportMesh(
         I_Info,
         rModelPart);
-}
-
-ImportDataReturnType ImportData(
-    const CoSimIO::Info& I_Info)
-{
-    std::vector<double> values;
-
-    auto info = CoSimIO::ImportData(
-        I_Info,
-        values);
-
-    return std::make_tuple(info, values);
-}
-
-CoSimIO::Info ExportData(
-    const CoSimIO::Info& I_Info,
-    std::vector<double>& rValues)
-{
-    return CoSimIO::ExportData(
-        I_Info,
-        rValues);
 }
 
 } // namespace CoSimIO_Py_Wrappers
@@ -101,8 +70,16 @@ PYBIND11_MODULE(CoSimIO, m)
     // m.def("ImportMesh", &CoSimIO::ImportMesh);
     // m.def("ExportMesh", &CoSimIO::ExportMesh);
 
-    m.def("ImportData", CoSimIO_Py_Wrappers::ImportData);
-    m.def("ExportData", CoSimIO_Py_Wrappers::ExportData);
+    m.def("ImportData", [](const CoSimIO::Info& I_Info, std::vector<double>& rValues){
+        return CoSimIO::ImportData(
+        I_Info,
+        rValues);
+    });
+    m.def("ExportData", [](const CoSimIO::Info& I_Info, const std::vector<double>& rValues){
+        return CoSimIO::ExportData(
+        I_Info,
+        rValues);
+    });
 
     m.def("ImportInfo", &CoSimIO::ImportInfo);
     m.def("ExportInfo", &CoSimIO::ExportInfo);

--- a/co_sim_io/python/vector_to_python.hpp
+++ b/co_sim_io/python/vector_to_python.hpp
@@ -43,6 +43,7 @@ public:
 private:
     std::vector<TDataType> mVector;
 };
+
 }
 
 void AddCoSimIOVectorToPython(pybind11::module& m)

--- a/co_sim_io/python/vector_to_python.hpp
+++ b/co_sim_io/python/vector_to_python.hpp
@@ -1,0 +1,90 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef CO_SIM_IO_VECTOR_TO_PYHON_INCLUDED
+#define CO_SIM_IO_VECTOR_TO_PYHON_INCLUDED
+
+// Exposure of the CoSimIO to Python
+
+// System includes
+#include <vector>
+#include <sstream>
+
+// pybind includes
+#include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
+
+namespace {
+
+// small wrapper around std::vector for using it in Python
+template<typename TDataType>
+class VectorWrapper
+{
+public:
+    VectorWrapper() = default;
+    VectorWrapper(const std::vector<TDataType>& I_Vector)
+        : mVector(I_Vector) {};
+
+    VectorWrapper(const VectorWrapper& Other) : mVector(Other.mVector) {}
+    VectorWrapper& operator=(const VectorWrapper&) = delete;
+
+    std::vector<TDataType>& Vector() {return mVector;}
+    const std::vector<TDataType>& Vector() const {return mVector;}
+
+private:
+    std::vector<TDataType> mVector;
+};
+}
+
+void AddCoSimIOVectorToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    using DataType = double;
+    using VectorType = VectorWrapper<DataType>;
+
+    py::class_<VectorType>(m,"Vector")
+        .def(py::init<>())
+        .def(py::init<const std::vector<DataType>&>())
+        .def(py::init<const VectorType&>())
+        .def("__len__", [](VectorType& I_Vec)
+            { return I_Vec.Vector().size(); } )
+        .def("size", [](VectorType& I_Vec)
+            { return I_Vec.Vector().size(); } )
+        .def("resize", [](VectorType& I_Vec, const std::size_t& I_NewSize)
+            { I_Vec.Vector().resize(I_NewSize); } )
+        .def("append", [](VectorType& I_Vec, const DataType& I_Val)
+            { I_Vec.Vector().push_back(I_Val); } )
+        .def("__setitem__", [](VectorType& I_Vec, const std::size_t I_Index, const DataType& I_Val)
+            { I_Vec.Vector()[I_Index] = I_Val; } )
+        .def("__getitem__", [](VectorType& I_Vec, const std::size_t I_Index)
+            { return I_Vec.Vector()[I_Index]; } )
+        .def("__iter__",     [](VectorType& I_Vec)
+            {return py::make_iterator(I_Vec.Vector().begin(), I_Vec.Vector().end());},  py::keep_alive<0,1>())
+        .def("__str__",   [](const VectorType& I_Vec)
+            {
+                std::stringstream ss;
+                const std::size_t size = I_Vec.Vector().size();
+
+                ss << "[";
+                if(size>0) ss << I_Vec.Vector()[0];
+                if(size>1) {
+                    for(std::size_t i=1; i<size; ++i)
+                        ss<<", "<<I_Vec.Vector()[i];
+                }
+                ss << "]";
+
+                return ss.str(); } )
+        ;
+}
+
+#endif // CO_SIM_IO_VECTOR_TO_PYHON_INCLUDED

--- a/co_sim_io/python/vector_to_python.hpp
+++ b/co_sim_io/python/vector_to_python.hpp
@@ -23,64 +23,43 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-namespace {
+using VEC_DataType = double;
+using VEC_VectorType = std::vector<VEC_DataType>;
 
-// small wrapper around std::vector for using it in Python
-template<typename TDataType>
-class VectorWrapper
-{
-public:
-    VectorWrapper() = default;
-    VectorWrapper(const std::vector<TDataType>& I_Vector)
-        : mVector(I_Vector) {};
-
-    VectorWrapper(const VectorWrapper& Other) : mVector(Other.mVector) {}
-    VectorWrapper& operator=(const VectorWrapper&) = delete;
-
-    std::vector<TDataType>& Vector() {return mVector;}
-    const std::vector<TDataType>& Vector() const {return mVector;}
-
-private:
-    std::vector<TDataType> mVector;
-};
-
-}
+PYBIND11_MAKE_OPAQUE(VEC_VectorType)
 
 void AddCoSimIOVectorToPython(pybind11::module& m)
 {
     namespace py = pybind11;
 
-    using DataType = double;
-    using VectorType = VectorWrapper<DataType>;
-
-    py::class_<VectorType>(m,"Vector")
+    py::class_<VEC_VectorType>(m,"Vector")
         .def(py::init<>())
-        .def(py::init<const std::vector<DataType>&>())
-        .def(py::init<const VectorType&>())
-        .def("__len__", [](VectorType& I_Vec)
-            { return I_Vec.Vector().size(); } )
-        .def("size", [](VectorType& I_Vec)
-            { return I_Vec.Vector().size(); } )
-        .def("resize", [](VectorType& I_Vec, const std::size_t& I_NewSize)
-            { I_Vec.Vector().resize(I_NewSize); } )
-        .def("append", [](VectorType& I_Vec, const DataType& I_Val)
-            { I_Vec.Vector().push_back(I_Val); } )
-        .def("__setitem__", [](VectorType& I_Vec, const std::size_t I_Index, const DataType& I_Val)
-            { I_Vec.Vector()[I_Index] = I_Val; } )
-        .def("__getitem__", [](VectorType& I_Vec, const std::size_t I_Index)
-            { return I_Vec.Vector()[I_Index]; } )
-        .def("__iter__",     [](VectorType& I_Vec)
-            {return py::make_iterator(I_Vec.Vector().begin(), I_Vec.Vector().end());},  py::keep_alive<0,1>())
-        .def("__str__",   [](const VectorType& I_Vec)
+        .def(py::init<const std::vector<VEC_DataType>&>())
+        .def(py::init<const VEC_VectorType&>())
+        .def("__len__", [](VEC_VectorType& v)
+            { return v.size(); } )
+        .def("size", [](VEC_VectorType& v)
+            { return v.size(); } )
+        .def("resize", [](VEC_VectorType& v, const std::size_t& size)
+            { v.resize(size); } )
+        .def("append", [](VEC_VectorType& v, const VEC_DataType& val)
+            { v.push_back(val); } )
+        .def("__setitem__", [](VEC_VectorType& v, const std::size_t I_Index, const VEC_DataType& val)
+            { v[I_Index] = val; } )
+        .def("__getitem__", [](VEC_VectorType& v, const std::size_t I_Index)
+            { return v[I_Index]; } )
+        .def("__iter__",     [](VEC_VectorType& v)
+            {return py::make_iterator(v.begin(), v.end());},  py::keep_alive<0,1>())
+        .def("__str__",   [](const VEC_VectorType& v)
             {
                 std::stringstream ss;
-                const std::size_t size = I_Vec.Vector().size();
+                const std::size_t size = v.size();
 
                 ss << "[";
-                if(size>0) ss << I_Vec.Vector()[0];
+                if(size>0) ss << v[0];
                 if(size>1) {
                     for(std::size_t i=1; i<size; ++i)
-                        ss<<", "<<I_Vec.Vector()[i];
+                        ss<<", "<<v[i];
                 }
                 ss << "]";
 

--- a/co_sim_io/python/vector_to_python.hpp
+++ b/co_sim_io/python/vector_to_python.hpp
@@ -23,34 +23,61 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 
-using VEC_DataType = double;
-using VEC_VectorType = std::vector<VEC_DataType>;
+//
+#include "../impl/define.hpp"
 
-PYBIND11_MAKE_OPAQUE(VEC_VectorType)
+// has to be done outside of any namespace!
+PYBIND11_MAKE_OPAQUE(std::vector<int>)
+PYBIND11_MAKE_OPAQUE(std::vector<double>)
 
-void AddCoSimIOVectorToPython(pybind11::module& m)
+namespace {
+
+template<typename TDataType>
+void AddVectorWithTypeToPython(pybind11::module& m, const std::string& Name)
 {
     namespace py = pybind11;
 
-    py::class_<VEC_VectorType>(m,"Vector")
+    using VectorType = std::vector<TDataType>;
+
+    const std::string full_name = Name+"Vector";
+
+    py::class_<VectorType>(m, full_name.c_str())
         .def(py::init<>())
-        .def(py::init<const std::vector<VEC_DataType>&>())
-        .def(py::init<const VEC_VectorType&>())
-        .def("__len__", [](VEC_VectorType& v)
+        .def(py::init<const VectorType&>())
+        .def(py::init( [](const py::list& l){
+            VectorType vec(l.size());
+            for(std::size_t i=0; i<l.size(); ++i) {
+                vec[i] = py::cast<TDataType>(l[i]);
+            }
+            return vec;
+        }))
+        .def(py::init( [Name](py::buffer b){
+            py::buffer_info info = b.request();
+            CO_SIM_IO_ERROR_IF(info.format != py::format_descriptor<TDataType>::value) << "Expected a " << Name << " array!";
+            CO_SIM_IO_ERROR_IF(info.ndim != 1) << "Buffer dimension of 1 is required, got: " << info.ndim << std::endl;
+            VectorType vec(info.shape[0]);
+            for (int i=0; i<info.shape[0]; ++i) {
+                vec[i] = static_cast<TDataType *>(info.ptr)[i];
+            }
+            return vec;
+        }))
+
+        .def("__len__", [](VectorType& v)
             { return v.size(); } )
-        .def("size", [](VEC_VectorType& v)
+        .def("size", [](VectorType& v)
             { return v.size(); } )
-        .def("resize", [](VEC_VectorType& v, const std::size_t& size)
+        .def("resize", [](VectorType& v, const std::size_t& size)
             { v.resize(size); } )
-        .def("append", [](VEC_VectorType& v, const VEC_DataType& val)
+        .def("append", [](VectorType& v, const TDataType& val)
             { v.push_back(val); } )
-        .def("__setitem__", [](VEC_VectorType& v, const std::size_t I_Index, const VEC_DataType& val)
+        .def("__setitem__", [](VectorType& v, const std::size_t I_Index, const TDataType& val)
             { v[I_Index] = val; } )
-        .def("__getitem__", [](VEC_VectorType& v, const std::size_t I_Index)
+        .def("__getitem__", [](VectorType& v, const std::size_t I_Index)
             { return v[I_Index]; } )
-        .def("__iter__",     [](VEC_VectorType& v)
+        .def("__iter__",     [](VectorType& v)
             {return py::make_iterator(v.begin(), v.end());},  py::keep_alive<0,1>())
-        .def("__str__",   [](const VEC_VectorType& v)
+
+        .def("__str__",   [](const VectorType& v)
             {
                 std::stringstream ss;
                 const std::size_t size = v.size();
@@ -65,6 +92,14 @@ void AddCoSimIOVectorToPython(pybind11::module& m)
 
                 return ss.str(); } )
         ;
+}
+
+}
+
+void AddCoSimIOVectorToPython(pybind11::module& m)
+{
+    AddVectorWithTypeToPython<int>(m, "Int");
+    AddVectorWithTypeToPython<double>(m, "Double");
 }
 
 #endif // CO_SIM_IO_VECTOR_TO_PYHON_INCLUDED

--- a/tests/co_sim_io/python/test_vector.py
+++ b/tests/co_sim_io/python/test_vector.py
@@ -167,17 +167,5 @@ class CoSimIO_IntVector(CoSimIO_Vector.BaseTests):
             self.assertEqual(a,v)
 
 
-# test with numpy => See Kratos: add_matrix_to_python.cpp => buffer_info
-
-# strcpy for C-connection_name
-
-
-# Paper:
-# - Not restricted to data (should be serializable)
-# - data transer - mapping - orchestrator are separeted => each can be exchnaged independently => can be adapted easily for many usecases
-# - show case
-
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/tests/co_sim_io/python/test_vector.py
+++ b/tests/co_sim_io/python/test_vector.py
@@ -25,31 +25,27 @@ class CoSimIO_Vector(unittest.TestCase):
     def test_basics(self):
         vec = CoSimIO.Vector()
         self.assertEqual(vec.size(), 0)
+        self.assertEqual(len(vec), 0)
 
         vec.append(15)
         self.assertEqual(vec.size(), 1)
+        self.assertEqual(len(vec), 1)
         self.assertAlmostEqual(vec[0], 15)
 
         vec.append(-1.45)
         self.assertEqual(vec.size(), 2)
+        self.assertEqual(len(vec), 2)
         self.assertAlmostEqual(vec[0], 15)
         self.assertAlmostEqual(vec[1], -1.45)
 
     def test_construction_from_objects(self):
         init_list = [1.0, 2.5, 3.3, -4.1, 17]
-        init_set = set(init_list)
 
         vec_from_list = CoSimIO.Vector(init_list)
         self.assertEqual(vec_from_list.size(), len(init_list))
 
-        vec_from_set = CoSimIO.Vector(init_set)
-        self.assertEqual(vec_from_set.size(), len(init_set))
-
         for l, v in zip(init_list, vec_from_list):
             self.assertAlmostEqual(l,v)
-
-        for s, v in zip(init_set, vec_from_list):
-            self.assertAlmostEqual(s,v)
 
     def test_copy_constructor(self):
         vec = CoSimIO.Vector()
@@ -67,7 +63,7 @@ class CoSimIO_Vector(unittest.TestCase):
         self.assertAlmostEqual(vec_copy[0], 0) # copy is unchanged
 
         vec.resize(5)
-        self.assertEqual(vec_copy.size(), 5)
+        self.assertEqual(vec_copy.size(), 10)
 
     def test_resize(self):
         vec = CoSimIO.Vector()
@@ -111,9 +107,9 @@ class CoSimIO_Vector(unittest.TestCase):
         self.assertEqual(counter, 23)
 
     def test_print(self):
-        vec = CoSimIO.Vector([1.0, 2.5, 3.3, -4.1, 17])
+        vec = CoSimIO.Vector([1.2, 2.5, 3.3, -4.1, 17])
 
-        self.assertMultiLineEqual(str(vec), "[1.0, 2.5, 3.3, -4.1, 17]\n")
+        self.assertMultiLineEqual(str(vec), "[1.2, 2.5, 3.3, -4.1, 17]")
 
 
 if __name__ == '__main__':

--- a/tests/co_sim_io/python/test_vector.py
+++ b/tests/co_sim_io/python/test_vector.py
@@ -15,101 +15,168 @@
 
 # python imports
 import unittest
+from abc import ABCMeta, abstractmethod
+
+try:
+    import numpy as np
+    numpy_available = True
+except:
+    numpy_available = False
 
 import CoSimIO
 
 
-class CoSimIO_Vector(unittest.TestCase):
-    maxDiff = None # to display all the diff
+class CoSimIO_Vector:
+    class BaseTests(unittest.TestCase, metaclass=ABCMeta):
+        maxDiff = None # to display all the diff
+        @abstractmethod
+        def _CreateVector(self, *args): pass
 
-    def test_basics(self):
-        vec = CoSimIO.Vector()
-        self.assertEqual(vec.size(), 0)
-        self.assertEqual(len(vec), 0)
+        def test_basics(self):
+            vec = self._CreateVector()
+            self.assertEqual(vec.size(), 0)
+            self.assertEqual(len(vec), 0)
 
-        vec.append(15)
-        self.assertEqual(vec.size(), 1)
-        self.assertEqual(len(vec), 1)
-        self.assertAlmostEqual(vec[0], 15)
+            vec.append(15)
+            self.assertEqual(vec.size(), 1)
+            self.assertEqual(len(vec), 1)
+            self.assertAlmostEqual(vec[0], 15)
 
-        vec.append(-1.45)
-        self.assertEqual(vec.size(), 2)
-        self.assertEqual(len(vec), 2)
-        self.assertAlmostEqual(vec[0], 15)
-        self.assertAlmostEqual(vec[1], -1.45)
+            vec.append(-3)
+            self.assertEqual(vec.size(), 2)
+            self.assertEqual(len(vec), 2)
+            self.assertAlmostEqual(vec[0], 15)
+            self.assertAlmostEqual(vec[1], -3)
 
-    def test_construction_from_objects(self):
-        init_list = [1.0, 2.5, 3.3, -4.1, 17]
+        def test_resize(self):
+            vec = self._CreateVector()
+            self.assertEqual(vec.size(), 0)
 
-        vec_from_list = CoSimIO.Vector(init_list)
-        self.assertEqual(vec_from_list.size(), len(init_list))
+            vec.resize(10)
+            self.assertEqual(vec.size(), 10)
 
-        for l, v in zip(init_list, vec_from_list):
-            self.assertAlmostEqual(l,v)
+            vec.resize(5)
+            self.assertEqual(vec.size(), 5)
 
-    def test_copy_constructor(self):
-        vec = CoSimIO.Vector()
-        for i in range(10):
-            vec.append(i)
+            vec.resize(23)
+            self.assertEqual(vec.size(), 23)
 
-        vec_copy = CoSimIO.Vector(vec)
+        def test_iterators(self):
+            vec = self._CreateVector()
+            for i in range(10):
+                vec.append(i)
 
-        self.assertEqual(vec.size(), vec_copy.size())
-        for v, v_c in zip(vec, vec_copy):
-            self.assertAlmostEqual(v, v_c)
+            self.assertEqual(vec.size(), 10)
 
-        # make sure that it is a deep and not a shallow copy
-        vec[0] = 123456
-        self.assertAlmostEqual(vec_copy[0], 0) # copy is unchanged
+            counter = 0
+            for i, v in enumerate(vec):
+                self.assertAlmostEqual(i,v)
+                counter += 1
+            self.assertEqual(counter, 10)
 
-        vec.resize(5)
-        self.assertEqual(vec_copy.size(), 10)
+            # check for after resize to smaller and larger
+            counter = 0
+            vec.resize(5)
+            for i, v in enumerate(vec):
+                self.assertAlmostEqual(i,v)
+                counter += 1
+            self.assertEqual(counter, 5)
 
-    def test_resize(self):
-        vec = CoSimIO.Vector()
-        self.assertEqual(vec.size(), 0)
+            counter = 0
+            vec.resize(23)
+            for i, v in enumerate(vec):
+                counter += 1
 
-        vec.resize(10)
-        self.assertEqual(vec.size(), 10)
+            self.assertEqual(counter, 23)
 
-        vec.resize(5)
-        self.assertEqual(vec.size(), 5)
+        def test_copy_constructor(self):
+            vec = self._CreateVector()
+            for i in range(10):
+                vec.append(i)
 
-        vec.resize(23)
-        self.assertEqual(vec.size(), 23)
+            vec_copy = self._CreateVector(vec)
 
-    def test_iterators(self):
-        vec = CoSimIO.Vector()
-        for i in range(10):
-            vec.append(i)
+            self.assertEqual(vec.size(), vec_copy.size())
+            for v, v_c in zip(vec, vec_copy):
+                self.assertAlmostEqual(v, v_c)
 
-        self.assertEqual(vec.size(), 10)
+            # make sure that it is a deep and not a shallow copy
+            vec[0] = 123456
+            self.assertAlmostEqual(vec_copy[0], 0) # copy is unchanged
 
-        counter = 0
-        for i, v in enumerate(vec):
-            self.assertAlmostEqual(i,v)
-            counter += 1
-        self.assertEqual(counter, 10)
+            vec.resize(5)
+            self.assertEqual(vec_copy.size(), 10)
 
-        # check for after resize to smaller and larger
-        counter = 0
-        vec.resize(5)
-        for i, v in enumerate(vec):
-            self.assertAlmostEqual(i,v)
-            counter += 1
-        self.assertEqual(counter, 5)
+        def test_construction_from_list(self):
+            init_list = [1, 2, 3, -4, 17]
 
-        counter = 0
-        vec.resize(23)
-        for i, v in enumerate(vec):
-            counter += 1
+            vec = self._CreateVector(init_list)
+            self.assertEqual(vec.size(), len(init_list))
 
-        self.assertEqual(counter, 23)
+            for l, v in zip(init_list, vec):
+                self.assertAlmostEqual(l,v)
+
+
+class CoSimIO_DoubleVector(CoSimIO_Vector.BaseTests):
+    def _CreateVector(self, *args):
+        return CoSimIO.DoubleVector(*args)
 
     def test_print(self):
-        vec = CoSimIO.Vector([1.2, 2.5, 3.3, -4.1, 17])
+        vec = self._CreateVector([1.2, 2.5, 3.3, -4.1, 17])
 
         self.assertMultiLineEqual(str(vec), "[1.2, 2.5, 3.3, -4.1, 17]")
+
+    def test_doubles(self):
+        # general tests are done with ints, hence explicitly checking with doubles
+        vec = self._CreateVector()
+        for i in range(10):
+            vec.append(i*1.5)
+
+        self.assertEqual(vec.size(), 10)
+
+        for i in range(10):
+            self.assertAlmostEqual(vec[i], i*1.5)
+
+    @unittest.skipUnless(numpy_available, "this test requries numpy")
+    def test_construction_from_numpy_array(self):
+        arr = np.array([1.1,2.2,-3.2,4,5,6.78,7,8.78,9], dtype=np.double)
+
+        vec = self._CreateVector(arr)
+        self.assertEqual(vec.size(), arr.size)
+
+        for a, v in zip(arr, vec):
+            self.assertAlmostEqual(a,v)
+
+class CoSimIO_IntVector(CoSimIO_Vector.BaseTests):
+    def _CreateVector(self, *args):
+        return CoSimIO.IntVector(*args)
+
+    def test_print(self):
+        vec = self._CreateVector([1, 2, 3, -4, 17])
+
+        self.assertMultiLineEqual(str(vec), "[1, 2, 3, -4, 17]")
+
+    @unittest.skipUnless(numpy_available, "this test requries numpy")
+    def test_construction_from_numpy_array(self):
+        arr = np.array([10,2,-3,4,5,6,7,8,9], dtype=np.intc)
+
+        vec = self._CreateVector(arr)
+        self.assertEqual(vec.size(), arr.size)
+
+        for a, v in zip(arr, vec):
+            self.assertEqual(a,v)
+
+
+# test with numpy => See Kratos: add_matrix_to_python.cpp => buffer_info
+
+# strcpy for C-connection_name
+
+
+# Paper:
+# - Not restricted to data (should be serializable)
+# - data transer - mapping - orchestrator are separeted => each can be exchnaged independently => can be adapted easily for many usecases
+# - show case
+
 
 
 if __name__ == '__main__':

--- a/tests/co_sim_io/python/test_vector.py
+++ b/tests/co_sim_io/python/test_vector.py
@@ -1,0 +1,120 @@
+#     ______     _____ _           ________
+#    / ____/___ / ___/(_)___ ___  /  _/ __ |
+#   / /   / __ \\__ \/ / __ `__ \ / // / / /
+#  / /___/ /_/ /__/ / / / / / / // // /_/ /
+#  \____/\____/____/_/_/ /_/ /_/___/\____/
+#  Kratos CoSimulationApplication
+#
+#  License:         BSD License, see license.txt
+#
+#  Main authors:    Philipp Bucher (https://github.com/philbucher)
+#
+
+# tests for the python exposure of CoSimIO::Vector
+# (which is a small python wrapper fro std::vector<double>)
+
+# python imports
+import unittest
+
+import CoSimIO
+
+
+class CoSimIO_Vector(unittest.TestCase):
+    maxDiff = None # to display all the diff
+
+    def test_basics(self):
+        vec = CoSimIO.Vector()
+        self.assertEqual(vec.size(), 0)
+
+        vec.append(15)
+        self.assertEqual(vec.size(), 1)
+        self.assertAlmostEqual(vec[0], 15)
+
+        vec.append(-1.45)
+        self.assertEqual(vec.size(), 2)
+        self.assertAlmostEqual(vec[0], 15)
+        self.assertAlmostEqual(vec[1], -1.45)
+
+    def test_construction_from_objects(self):
+        init_list = [1.0, 2.5, 3.3, -4.1, 17]
+        init_set = set(init_list)
+
+        vec_from_list = CoSimIO.Vector(init_list)
+        self.assertEqual(vec_from_list.size(), len(init_list))
+
+        vec_from_set = CoSimIO.Vector(init_set)
+        self.assertEqual(vec_from_set.size(), len(init_set))
+
+        for l, v in zip(init_list, vec_from_list):
+            self.assertAlmostEqual(l,v)
+
+        for s, v in zip(init_set, vec_from_list):
+            self.assertAlmostEqual(s,v)
+
+    def test_copy_constructor(self):
+        vec = CoSimIO.Vector()
+        for i in range(10):
+            vec.append(i)
+
+        vec_copy = CoSimIO.Vector(vec)
+
+        self.assertEqual(vec.size(), vec_copy.size())
+        for v, v_c in zip(vec, vec_copy):
+            self.assertAlmostEqual(v, v_c)
+
+        # make sure that it is a deep and not a shallow copy
+        vec[0] = 123456
+        self.assertAlmostEqual(vec_copy[0], 0) # copy is unchanged
+
+        vec.resize(5)
+        self.assertEqual(vec_copy.size(), 5)
+
+    def test_resize(self):
+        vec = CoSimIO.Vector()
+        self.assertEqual(vec.size(), 0)
+
+        vec.resize(10)
+        self.assertEqual(vec.size(), 10)
+
+        vec.resize(5)
+        self.assertEqual(vec.size(), 5)
+
+        vec.resize(23)
+        self.assertEqual(vec.size(), 23)
+
+    def test_iterators(self):
+        vec = CoSimIO.Vector()
+        for i in range(10):
+            vec.append(i)
+
+        self.assertEqual(vec.size(), 10)
+
+        counter = 0
+        for i, v in enumerate(vec):
+            self.assertAlmostEqual(i,v)
+            counter += 1
+        self.assertEqual(counter, 10)
+
+        # check for after resize to smaller and larger
+        counter = 0
+        vec.resize(5)
+        for i, v in enumerate(vec):
+            self.assertAlmostEqual(i,v)
+            counter += 1
+        self.assertEqual(counter, 5)
+
+        counter = 0
+        vec.resize(23)
+        for i, v in enumerate(vec):
+            counter += 1
+
+        self.assertEqual(counter, 23)
+
+    def test_print(self):
+        vec = CoSimIO.Vector([1.0, 2.5, 3.3, -4.1, 17])
+
+        self.assertMultiLineEqual(str(vec), "[1.0, 2.5, 3.3, -4.1, 17]\n")
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/integration_tutorials/python/export_data.py
+++ b/tests/integration_tutorials/python/export_data.py
@@ -29,7 +29,7 @@ cosimio_check_equal(return_info.GetInt("connection_status"), CoSimIO.ConnectionS
 connection_name = return_info.GetString("connection_name")
 
 # Exporting data
-data_to_be_send=[3.14] * 4
+data_to_be_send=CoSimIO.DoubleVector([3.14] * 4)
 info = CoSimIO.Info()
 info.SetString("identifier", "vector_of_pi")
 info.SetString("connection_name", connection_name)

--- a/tests/integration_tutorials/python/import_data.py
+++ b/tests/integration_tutorials/python/import_data.py
@@ -28,15 +28,16 @@ return_info = CoSimIO.Connect(settings)
 cosimio_check_equal(return_info.GetInt("connection_status"), CoSimIO.ConnectionStatus.Connected)
 connection_name = return_info.GetString("connection_name")
 
-# Importing data
+# # Importing data
 info = CoSimIO.Info()
 info.SetString("identifier", "vector_of_pi")
 info.SetString("connection_name", connection_name)
-return_info, received_data = CoSimIO.ImportData(info)
+vec_to_import=CoSimIO.DoubleVector()
+return_info = CoSimIO.ImportData(info, vec_to_import)
 
-cosimio_check_equal(len(received_data), 4)
+cosimio_check_equal(len(vec_to_import), 4)
 
-for value in received_data:
+for value in vec_to_import:
     cosimio_check_equal(value, 3.14)
 
 # Disconnecting


### PR DESCRIPTION
This PR adds the `CoSimIO.Vector`
this object is a tiny wrapper around `std::vector<double>` to be used in Python. The goals are:
- Make the data exchange more efficient, having a dedicated object will not require to copy back and forth the data each time (currently pybind does this automatically each time we pass data btw Python & C++)
- The interfaces are now unified, esp for the `ImportData` we will not need to return a tuple (of `CoSimIO.Info` & the data (a `py::list`)) any more but now only the `Info`

=> the Interface will be updated in a follow up PR