### PR TITLE
Save&Load for DataContainer & ModelPart

### DIFF
--- a/co_sim_io/impl/communication/file_communication.hpp
+++ b/co_sim_io/impl/communication/file_communication.hpp
@@ -151,7 +151,7 @@ private:
         CheckStream(input_file, file_name);
 
         Info imported_info;
-        imported_info.Load(input_file);
+        imported_info.Load(input_file, StreamMode::ASCII);
 
         input_file.close(); // TODO check return value?
         RemovePath(file_name);
@@ -176,7 +176,7 @@ private:
         output_file.open(GetTempFileName(file_name));
         CheckStream(output_file, file_name);
 
-        I_Info.Save(output_file);
+        I_Info.Save(output_file, StreamMode::ASCII);
 
         output_file.close();
         MakeFileVisible(file_name);

--- a/co_sim_io/impl/data_container.hpp
+++ b/co_sim_io/impl/data_container.hpp
@@ -54,6 +54,15 @@ public:
     {
         return this->data()[Index];
     }
+
+    void Save(std::ostream& O_OutStream) const
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
+    void Load(std::istream& I_InStream)
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
 };
 
 /// output stream function

--- a/co_sim_io/impl/data_container.hpp
+++ b/co_sim_io/impl/data_container.hpp
@@ -55,7 +55,7 @@ public:
         return this->data()[Index];
     }
 
-    void Save(std::ostream& O_OutStream) const
+    void Save(std::ostream& O_OutStream, StreamMode Mode) const
     {
         O_OutStream << size() << "\n";
         for (std::size_t i=0; i<size(); ++i) {
@@ -63,7 +63,7 @@ public:
         }
     }
 
-    void Load(std::istream& I_InStream)
+    void Load(std::istream& I_InStream, StreamMode Mode)
     {
         std::size_t size_data;
         I_InStream >> size_data; // the first number in the file is the size of the data

--- a/co_sim_io/impl/data_container.hpp
+++ b/co_sim_io/impl/data_container.hpp
@@ -58,11 +58,9 @@ public:
     void Save(std::ostream& O_OutStream) const
     {
         O_OutStream << size() << "\n";
-
-        for (std::size_t i=0; i<size()-1; ++i) {
+        for (std::size_t i=0; i<size(); ++i) {
             O_OutStream << data()[i] << " ";
         }
-        O_OutStream << data()[size()-1]; // outside to not have trailing whitespace
     }
 
     void Load(std::istream& I_InStream)
@@ -70,10 +68,7 @@ public:
         std::size_t size_data;
         I_InStream >> size_data; // the first number in the file is the size of the data
 
-        if (size() != size_data) {
-            resize(size_data);
-        }
-
+        if (size() != size_data) {resize(size_data);}
         for (std::size_t i=0; i<size_data; ++i) {
             I_InStream >> data()[i];
         }

--- a/co_sim_io/impl/data_container.hpp
+++ b/co_sim_io/impl/data_container.hpp
@@ -57,11 +57,26 @@ public:
 
     void Save(std::ostream& O_OutStream) const
     {
-        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+        O_OutStream << size() << "\n";
+
+        for (std::size_t i=0; i<size()-1; ++i) {
+            O_OutStream << data()[i] << " ";
+        }
+        O_OutStream << data()[size()-1]; // outside to not have trailing whitespace
     }
+
     void Load(std::istream& I_InStream)
     {
-        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+        std::size_t size_data;
+        I_InStream >> size_data; // the first number in the file is the size of the data
+
+        if (size() != size_data) {
+            resize(size_data);
+        }
+
+        for (std::size_t i=0; i<size_data; ++i) {
+            I_InStream >> data()[i];
+        }
     }
 };
 

--- a/co_sim_io/impl/define.hpp
+++ b/co_sim_io/impl/define.hpp
@@ -82,6 +82,12 @@ enum class ElementType
     Point3D
 };
 
+enum class StreamMode
+{
+    ASCII,
+    BINARY
+};
+
 // Note: std::make_unique is C++14, this can be updated once we upgrade from C++11
 template<typename C, typename...Args>
 std::unique_ptr<C> make_unique(Args &&...args) {

--- a/co_sim_io/impl/info.hpp
+++ b/co_sim_io/impl/info.hpp
@@ -165,7 +165,7 @@ public:
         return mOptions.size();
     }
 
-    void Save(std::ostream& O_OutStream) const
+    void Save(std::ostream& O_OutStream, StreamMode Mode) const
     {
         static std::map<std::string, std::string> s_registered_object_names {
             {typeid(Internals::InfoData<int>).name(),         "InfoData_int"},
@@ -185,7 +185,7 @@ public:
             O_OutStream << "\n";
         }
     }
-    void Load(std::istream& I_InStream)
+    void Load(std::istream& I_InStream, StreamMode Mode)
     {
         static std::map<std::string, std::shared_ptr<Internals::InfoDataBase>> s_registered_object_prototypes {
             {"InfoData_int"    , std::make_shared<Internals::InfoData<int>>(1)},

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -266,7 +266,7 @@ public:
         return *it_elem;
     }
 
-    void Save(std::ostream& O_OutStream) const
+    void Save(std::ostream& O_OutStream, StreamMode Mode) const
     {
         O_OutStream << mName << "\n";
         O_OutStream << NumberOfNodes() << "\n";
@@ -292,7 +292,7 @@ public:
         }
     }
 
-    void Load(std::istream& I_InStream)
+    void Load(std::istream& I_InStream, StreamMode Mode)
     {
         I_InStream >> mName;
         std::size_t num_nodes, num_elements;

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -318,10 +318,10 @@ public:
             I_InStream >> elem_type_load;
 
             ElementType elem_type = static_cast<ElementType>(elem_type_load);
-            int num_nodes_elem = Internals::GetNumberOfNodesForElementType(elem_type);
+            std::size_t num_nodes_elem = Internals::GetNumberOfNodesForElementType(elem_type);
 
             if (elem_nodes.size() != num_nodes_elem) {elem_nodes.resize(num_nodes_elem);}
-            for (int i=0; i<num_nodes_elem; ++i) {
+            for (std::size_t i=0; i<num_nodes_elem; ++i) {
                 IdType node_id;
                 I_InStream >> node_id;
                 elem_nodes[i] = node_id;

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -321,7 +321,7 @@ public:
             int num_nodes_elem = Internals::GetNumberOfNodesForElementType(elem_type);
 
             if (elem_nodes.size() != num_nodes_elem) {elem_nodes.resize(num_nodes_elem);}
-            for (std::size_t i=0; i<num_nodes_elem; ++i) {
+            for (int i=0; i<num_nodes_elem; ++i) {
                 IdType node_id;
                 I_InStream >> node_id;
                 elem_nodes[i] = node_id;

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -66,6 +66,15 @@ public:
     double Z() const { return mZ; }
     CoordinatesType Coordinates() const { return {mX, mY, mZ}; }
 
+    void Save(std::ostream& O_OutStream) const
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
+    void Load(std::istream& I_InStream)
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
+
     void Print(std::ostream& rOStream) const
     {
         rOStream << "CoSimIO-Node; Id: " << Id() << "\n";
@@ -117,6 +126,15 @@ public:
     std::size_t NumberOfNodes() const { return mNodes.size(); }
     NodesContainerType::const_iterator NodesBegin() const { return mNodes.begin(); }
     NodesContainerType::const_iterator NodesEnd() const { return mNodes.end(); }
+
+    void Save(std::ostream& O_OutStream) const
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
+    void Load(std::istream& I_InStream)
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
 
     void Print(std::ostream& rOStream) const
     {
@@ -245,6 +263,15 @@ public:
         auto it_elem = FindElement(I_Id);
         CO_SIM_IO_ERROR_IF(it_elem == mElements.end()) << "Element with Id " << I_Id << " does not exist!" << std::endl;
         return *it_elem;
+    }
+
+    void Save(std::ostream& O_OutStream) const
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+    }
+    void Load(std::istream& I_InStream)
+    {
+        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
     }
 
     void Print(std::ostream& rOStream) const

--- a/co_sim_io/impl/model_part.hpp
+++ b/co_sim_io/impl/model_part.hpp
@@ -68,11 +68,12 @@ public:
 
     void Save(std::ostream& O_OutStream) const
     {
-        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+        O_OutStream << mId << " " << mX << " " << mY << " " << mZ << "\n";
     }
+
     void Load(std::istream& I_InStream)
     {
-        CO_SIM_IO_ERROR << "NotImplementedError" << std::endl;
+        I_InStream >> mId >> mX >> mY >> mZ;
     }
 
     void Print(std::ostream& rOStream) const

--- a/tests/co_sim_io/impl/co_sim_io_testing.hpp
+++ b/tests/co_sim_io/impl/co_sim_io_testing.hpp
@@ -23,6 +23,14 @@ for (std::size_t _i=0; _i<a.size(); ++_i) {       \
 }                                                 \
 }
 
+#define CO_SIM_IO_CHECK_VECTOR_EQUAL(a, b) {      \
+REQUIRE_EQ(a.size(), b.size());                   \
+for (std::size_t _i=0; _i<a.size(); ++_i) {       \
+   CHECK_MESSAGE(a[_i] == b[_i],                  \
+   "Mismatch in component: " << _i);              \
+}                                                 \
+}
+
 #define CO_SIM_IO_CHECK_VECTOR_NEAR_SIZE(a, b, s) { \
 REQUIRE_GE(a.size(), s);                            \
 REQUIRE_GE(b.size(), s);                            \
@@ -30,4 +38,13 @@ for (std::size_t _i=0; _i<s; ++_i) {                \
    CHECK_MESSAGE(a[_i] == doctest::Approx(b[_i]),   \
    "Mismatch in component: " << _i);                \
 }                                                   \
+}
+
+#define CO_SIM_IO_CHECK_VECTOR_EQUAL_SIZE(a, b, s) { \
+REQUIRE_GE(a.size(), s);                             \
+REQUIRE_GE(b.size(), s);                             \
+for (std::size_t _i=0; _i<s; ++_i) {                 \
+   CHECK_MESSAGE(a[_i] == b[_i],                     \
+   "Mismatch in component: " << _i);                 \
+}                                                    \
 }

--- a/tests/co_sim_io/impl/co_sim_io_testing.hpp
+++ b/tests/co_sim_io/impl/co_sim_io_testing.hpp
@@ -13,6 +13,9 @@
 // External includes
 #include "doctest/doctest.h"
 
+// Project includes
+#include "impl/model_part.hpp"
+
 // Custom macros
 
 #define CO_SIM_IO_CHECK_VECTOR_NEAR(a, b) {       \
@@ -47,4 +50,49 @@ for (std::size_t _i=0; _i<s; ++_i) {                 \
    CHECK_MESSAGE(a[_i] == b[_i],                     \
    "Mismatch in component: " << _i);                 \
 }                                                    \
+}
+
+inline void CheckNodesAreEqual(
+    const CoSimIO::Node& Node1,
+    const CoSimIO::Node& Node2)
+{
+    CHECK_EQ(Node1.Id(), Node2.Id());
+    CHECK_EQ(Node1.X(), doctest::Approx(Node2.X()));
+    CHECK_EQ(Node1.Y(), doctest::Approx(Node2.Y()));
+    CHECK_EQ(Node1.Z(), doctest::Approx(Node2.Z()));
+}
+
+inline void CheckElementsAreEqual(
+    const CoSimIO::Element& Element1,
+    const CoSimIO::Element& Element2)
+{
+    // basic checks
+    CHECK_EQ(Element1.Id(), Element2.Id());
+    CHECK_EQ(Element1.Type(), Element2.Type());
+    REQUIRE_EQ(Element1.NumberOfNodes(), Element2.NumberOfNodes());
+
+    // check nodes
+    for (std::size_t i=0; i< Element1.NumberOfNodes(); ++i) {
+        CheckNodesAreEqual(**(Element1.NodesBegin()+i), **(Element2.NodesBegin()+i));
+    }
+}
+
+inline void CheckModelPartsAreEqual(
+    const CoSimIO::ModelPart& ModelPart1,
+    const CoSimIO::ModelPart& ModelPart2)
+{
+    // basic checks
+    CHECK_EQ(ModelPart1.Name(), ModelPart2.Name());
+    REQUIRE_EQ(ModelPart1.NumberOfNodes(), ModelPart2.NumberOfNodes());
+    REQUIRE_EQ(ModelPart1.NumberOfElements(), ModelPart2.NumberOfElements());
+
+    // check nodes
+    for (std::size_t i=0; i< ModelPart1.NumberOfNodes(); ++i) {
+        CheckNodesAreEqual(**(ModelPart1.NodesBegin()+i), **(ModelPart2.NodesBegin()+i));
+    }
+
+    // check elements
+    for (std::size_t i=0; i< ModelPart1.NumberOfElements(); ++i) {
+        CheckElementsAreEqual(**(ModelPart1.ElementsBegin()+i), **(ModelPart2.ElementsBegin()+i));
+    }
 }

--- a/tests/co_sim_io/impl/test_communication.cpp
+++ b/tests/co_sim_io/impl/test_communication.cpp
@@ -24,51 +24,6 @@ namespace {
 
 using CoSimIO::ElementType;
 
-void CheckNodesAreEqual(
-    const CoSimIO::Node& Node1,
-    const CoSimIO::Node& Node2)
-{
-    CHECK_EQ(Node1.Id(), Node2.Id());
-    CHECK_EQ(Node1.X(), doctest::Approx(Node2.X()));
-    CHECK_EQ(Node1.Y(), doctest::Approx(Node2.Y()));
-    CHECK_EQ(Node1.Z(), doctest::Approx(Node2.Z()));
-}
-
-void CheckElementsAreEqual(
-    const CoSimIO::Element& Element1,
-    const CoSimIO::Element& Element2)
-{
-    // basic checks
-    CHECK_EQ(Element1.Id(), Element2.Id());
-    CHECK_EQ(Element1.Type(), Element2.Type());
-    REQUIRE_EQ(Element1.NumberOfNodes(), Element2.NumberOfNodes());
-
-    // check nodes
-    for (std::size_t i=0; i< Element1.NumberOfNodes(); ++i) {
-        CheckNodesAreEqual(**(Element1.NodesBegin()+i), **(Element2.NodesBegin()+i));
-    }
-}
-
-void CheckModelPartsAreEqual(
-    const CoSimIO::ModelPart& ModelPart1,
-    const CoSimIO::ModelPart& ModelPart2)
-{
-    // basic checks
-    CHECK_EQ(ModelPart1.Name(), ModelPart2.Name());
-    REQUIRE_EQ(ModelPart1.NumberOfNodes(), ModelPart2.NumberOfNodes());
-    REQUIRE_EQ(ModelPart1.NumberOfElements(), ModelPart2.NumberOfElements());
-
-    // check nodes
-    for (std::size_t i=0; i< ModelPart1.NumberOfNodes(); ++i) {
-        CheckNodesAreEqual(**(ModelPart1.NodesBegin()+i), **(ModelPart2.NodesBegin()+i));
-    }
-
-    // check elements
-    for (std::size_t i=0; i< ModelPart1.NumberOfElements(); ++i) {
-        CheckElementsAreEqual(**(ModelPart1.ElementsBegin()+i), **(ModelPart2.ElementsBegin()+i));
-    }
-}
-
 std::shared_ptr<CoSimIO::ModelPart> CreateNodesOnlyModelPart()
 {
     std::shared_ptr<CoSimIO::ModelPart> p_model_part(std::make_shared<CoSimIO::ModelPart>("nodes_model_part"));

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -276,7 +276,7 @@ TEST_CASE("DataContainer_save_load_double")
 
     SUBCASE("binary")
     {
-        std::stringstream test_stream;
+        std::stringstream test_stream(std::ios_base::in | std::ios_base::out | std::ios::binary);
         const_ref.Save(test_stream, StreamMode::BINARY);
         p_load_container->Load(test_stream, StreamMode::BINARY);
     }
@@ -307,7 +307,7 @@ TEST_CASE("DataContainer_save_load_int")
 
     SUBCASE("binary")
     {
-        std::stringstream test_stream;
+        std::stringstream test_stream(std::ios_base::in | std::ios_base::out | std::ios::binary);
         const_ref.Save(test_stream, StreamMode::BINARY);
         p_load_container->Load(test_stream, StreamMode::BINARY);
     }

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -265,13 +265,21 @@ TEST_CASE("DataContainer_save_load_double")
     const DataContainerBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<double>>(save_values));
     const DataContainerBase& const_ref = *p_save_container;
 
-    std::stringstream test_stream;
-
-    const_ref.Save(test_stream);
-
     DataContainerBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<double>>(load_values));
 
-    p_load_container->Load(test_stream);
+    SUBCASE("ascii")
+    {
+        std::stringstream test_stream;
+        const_ref.Save(test_stream, StreamMode::ASCII);
+        p_load_container->Load(test_stream, StreamMode::ASCII);
+    }
+
+    SUBCASE("binary")
+    {
+        std::stringstream test_stream;
+        const_ref.Save(test_stream, StreamMode::BINARY);
+        p_load_container->Load(test_stream, StreamMode::BINARY);
+    }
 
     CO_SIM_IO_CHECK_VECTOR_NEAR(save_values, load_values);
     CO_SIM_IO_CHECK_VECTOR_NEAR(const_ref, (*p_load_container));
@@ -288,13 +296,21 @@ TEST_CASE("DataContainer_save_load_int")
     const DataContainerIntBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<int>>(save_values));
     const DataContainerIntBase& const_ref = *p_save_container;
 
-    std::stringstream test_stream;
-
-    const_ref.Save(test_stream);
-
     DataContainerIntBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<int>>(load_values));
 
-    p_load_container->Load(test_stream);
+    SUBCASE("ascii")
+    {
+        std::stringstream test_stream;
+        const_ref.Save(test_stream, StreamMode::ASCII);
+        p_load_container->Load(test_stream, StreamMode::ASCII);
+    }
+
+    SUBCASE("binary")
+    {
+        std::stringstream test_stream;
+        const_ref.Save(test_stream, StreamMode::BINARY);
+        p_load_container->Load(test_stream, StreamMode::BINARY);
+    }
 
     CO_SIM_IO_CHECK_VECTOR_EQUAL(save_values, load_values);
     CO_SIM_IO_CHECK_VECTOR_EQUAL(const_ref, (*p_load_container));

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -263,6 +263,7 @@ TEST_CASE("DataContainer_save_load_double")
     std::vector<double> load_values;
 
     const DataContainerBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<double>>(save_values));
+    const DataContainerBase& const_ref = *p_save_container;
 
     std::stringstream test_stream;
 
@@ -273,7 +274,7 @@ TEST_CASE("DataContainer_save_load_double")
     p_load_container->Load(test_stream);
 
     CO_SIM_IO_CHECK_VECTOR_NEAR(save_values, load_values);
-    CO_SIM_IO_CHECK_VECTOR_NEAR((*p_save_container), (*p_load_container));
+    CO_SIM_IO_CHECK_VECTOR_NEAR(const_ref, (*p_load_container));
 }
 
 TEST_CASE("DataContainer_save_load_int")
@@ -285,6 +286,7 @@ TEST_CASE("DataContainer_save_load_int")
     std::vector<int> load_values;
 
     const DataContainerIntBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<int>>(save_values));
+    const DataContainerIntBase& const_ref = *p_save_container;
 
     std::stringstream test_stream;
 
@@ -295,7 +297,7 @@ TEST_CASE("DataContainer_save_load_int")
     p_load_container->Load(test_stream);
 
     CO_SIM_IO_CHECK_VECTOR_EQUAL(save_values, load_values);
-    CO_SIM_IO_CHECK_VECTOR_EQUAL((*p_save_container), (*p_load_container));
+    CO_SIM_IO_CHECK_VECTOR_EQUAL(const_ref, (*p_load_container));
 }
 
 } // TEST_SUITE("DataContainer")

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -12,6 +12,7 @@
 
 // System includes
 #include <memory>
+#include <sstream>
 #include <algorithm>
 
 // Project includes
@@ -23,7 +24,9 @@ namespace CoSimIO {
 namespace Internals { // DataContainer is in the Internals namespace
 
 using DataContainerBase = DataContainer<double>;
+using DataContainerIntBase = DataContainer<int>;
 using DataContainerBasePointer = std::unique_ptr<DataContainerBase>;
+using DataContainerIntBasePointer = std::unique_ptr<DataContainerIntBase>;
 using DataContainerStdVectorType = DataContainerStdVector<double>;
 using DataContainerRawMemoryType = DataContainerRawMemory<double>;
 using DataContainerStdVectorReadOnlyType = DataContainerStdVectorReadOnly<double>;
@@ -249,6 +252,50 @@ TEST_CASE("DataContainer_RawMemory_multiple_resizes")
 
     // deallocating memory
     free(data);
+}
+
+TEST_CASE("DataContainer_save_load_double")
+{
+    const std::vector<double> save_values {
+        1.0, -2.333, 15.88, 14.7, -99.6
+    };
+
+    std::vector<double> load_values;
+
+    const DataContainerBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<double>>(save_values));
+
+    std::stringstream test_stream;
+
+    p_save_container->Save(test_stream);
+
+    DataContainerBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<double>>(load_values));
+
+    p_load_container->Load(test_stream);
+
+    CO_SIM_IO_CHECK_VECTOR_NEAR(save_values, load_values);
+    CO_SIM_IO_CHECK_VECTOR_NEAR((*p_save_container), (*p_load_container));
+}
+
+TEST_CASE("DataContainer_save_load_int")
+{
+    const std::vector<int> save_values {
+        1,2,3,-6,-7789,6147,9423
+    };
+
+    std::vector<int> load_values;
+
+    const DataContainerIntBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<int>>(save_values));
+
+    std::stringstream test_stream;
+
+    p_save_container->Save(test_stream);
+
+    DataContainerIntBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<int>>(load_values));
+
+    p_load_container->Load(test_stream);
+
+    CO_SIM_IO_CHECK_VECTOR_EQUAL(save_values, load_values);
+    CO_SIM_IO_CHECK_VECTOR_EQUAL((*p_save_container), (*p_load_container));
 }
 
 } // TEST_SUITE("DataContainer")

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -267,7 +267,7 @@ TEST_CASE("DataContainer_save_load_double")
 
     std::stringstream test_stream;
 
-    p_save_container->Save(test_stream);
+    const_ref.Save(test_stream);
 
     DataContainerBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<double>>(load_values));
 
@@ -290,7 +290,7 @@ TEST_CASE("DataContainer_save_load_int")
 
     std::stringstream test_stream;
 
-    p_save_container->Save(test_stream);
+    const_ref.Save(test_stream);
 
     DataContainerIntBasePointer p_load_container(CoSimIO::make_unique<DataContainerStdVector<int>>(load_values));
 

--- a/tests/co_sim_io/impl/test_info.cpp
+++ b/tests/co_sim_io/impl/test_info.cpp
@@ -315,7 +315,7 @@ TEST_CASE("info_save_load")
 
     SUBCASE("binary")
     {
-        std::stringstream test_stream;
+        std::stringstream test_stream(std::ios_base::in | std::ios_base::out | std::ios::binary);
         info.Save(test_stream, StreamMode::BINARY);
         another_info.Load(test_stream, StreamMode::BINARY);
     }

--- a/tests/co_sim_io/impl/test_info.cpp
+++ b/tests/co_sim_io/impl/test_info.cpp
@@ -259,7 +259,7 @@ TEST_CASE("info_erase")
     CHECK_NOTHROW(info.Erase("whatever"));
 }
 
-TEST_CASE("info_save")
+TEST_CASE("info_save_ascii")
 {
     Info info;
     info.Set<std::string>("keyword", "awesome");
@@ -271,21 +271,21 @@ TEST_CASE("info_save")
 
     std::stringstream test_stream;
 
-    info.Save(test_stream);
+    info.Save(test_stream, StreamMode::ASCII);
 
     const std::string exp_string = "5\nchecking\nInfoData_int\n22\necho_level\nInfoData_int\n2\nis_converged\nInfoData_bool\n1\nkeyword\nInfoData_string\nawesome\ntol\nInfoData_double\n0.008\n";
 
     CHECK_EQ(test_stream.str(), exp_string);
 }
 
-TEST_CASE("info_load")
+TEST_CASE("info_load_ascii")
 {
     std::stringstream test_stream;
 
     test_stream << "5\nkeyword\nInfoData_string\nawesome\nis_converged\nInfoData_bool\n1\ntol\nInfoData_double\n1.225\necho_level\nInfoData_int\n2\nchecking\nInfoData_int\n22\n";
 
     Info info;
-    info.Load(test_stream);
+    info.Load(test_stream, StreamMode::ASCII);
 
     CHECK_EQ(info.Size(), 5);
     CHECK_EQ(info.Get<int>("checking"), 22);
@@ -304,12 +304,21 @@ TEST_CASE("info_save_load")
     info.Set<int>("echo_level", 2);
     info.Set<int>("checking", 22);
 
-    std::stringstream test_stream;
-
-    info.Save(test_stream);
-
     Info another_info;
-    another_info.Load(test_stream);
+
+    SUBCASE("ascii")
+    {
+        std::stringstream test_stream;
+        info.Save(test_stream, StreamMode::ASCII);
+        another_info.Load(test_stream, StreamMode::ASCII);
+    }
+
+    SUBCASE("binary")
+    {
+        std::stringstream test_stream;
+        info.Save(test_stream, StreamMode::BINARY);
+        another_info.Load(test_stream, StreamMode::BINARY);
+    }
 
     CHECK_EQ(another_info.Size(), 5);
     CHECK_EQ(another_info.Get<int>("checking"), 22);

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -89,8 +89,6 @@ TEST_CASE("node_save_load")
 
     node.Save(test_stream);
 
-    std::cerr << "Node save: " << test_stream.str();
-
     loaded_node.Load(test_stream);
 
     CHECK_EQ(node.Id(), loaded_node.Id());
@@ -424,6 +422,38 @@ TEST_CASE("model_part_ostream")
     test_stream << model_part;
 
     CHECK_EQ(test_stream.str(), exp_string);
+}
+
+TEST_CASE("model_part_save_load")
+{
+    ModelPart model_part("for_test");
+
+    SUBCASE("empty")
+    {
+        // does nothing
+    }
+
+    SUBCASE("with_entities")
+    {
+        const int node_ids[] = {2, 159, 61};
+        const std::array<double, 3> node_coords = {1.0, -2.7, 9.44};
+        model_part.CreateNewNode(node_ids[0], node_coords[0], node_coords[1], node_coords[2]);
+        model_part.CreateNewNode(node_ids[1], node_coords[1], node_coords[2], node_coords[0]);
+        model_part.CreateNewNode(node_ids[2], node_coords[2], node_coords[0], node_coords[1]);
+
+        model_part.CreateNewElement(15, CoSimIO::ElementType::Point2D, {node_ids[0]});
+        model_part.CreateNewElement(73, CoSimIO::ElementType::Line2D2, {node_ids[1], node_ids[2]});
+        model_part.CreateNewElement(47, CoSimIO::ElementType::Triangle3D3, {node_ids[1], node_ids[2], node_ids[0]});
+    }
+
+    std::stringstream test_stream;
+    model_part.Save(test_stream);
+
+    ModelPart loaded_model_part("xxx");
+    loaded_model_part.Load(test_stream);
+
+    CheckModelPartsAreEqual(model_part, loaded_model_part);
+
 }
 
 } // TEST_SUITE("ModelPart")

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -91,11 +91,7 @@ TEST_CASE("node_save_load")
 
     loaded_node.Load(test_stream);
 
-    CHECK_EQ(node.Id(), loaded_node.Id());
-
-    CHECK_EQ(node.X(), doctest::Approx(loaded_node.X()));
-    CHECK_EQ(node.Y(), doctest::Approx(loaded_node.Y()));
-    CHECK_EQ(node.Z(), doctest::Approx(loaded_node.Z()));
+    CheckNodesAreEqual(node, loaded_node);
 }
 
 TEST_CASE("element_basics")
@@ -453,7 +449,6 @@ TEST_CASE("model_part_save_load")
     loaded_model_part.Load(test_stream);
 
     CheckModelPartsAreEqual(model_part, loaded_model_part);
-
 }
 
 } // TEST_SUITE("ModelPart")

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -448,30 +448,31 @@ TEST_CASE("model_part_ostream")
 TEST_CASE("model_part_save_load")
 {
     ModelPart model_part("for_test");
-
-    SUBCASE("empty")
-    {
-        // does nothing
-    }
-
-    SUBCASE("with_entities")
-    {
-        const int node_ids[] = {2, 159, 61};
-        const std::array<double, 3> node_coords = {1.0, -2.7, 9.44};
-        model_part.CreateNewNode(node_ids[0], node_coords[0], node_coords[1], node_coords[2]);
-        model_part.CreateNewNode(node_ids[1], node_coords[1], node_coords[2], node_coords[0]);
-        model_part.CreateNewNode(node_ids[2], node_coords[2], node_coords[0], node_coords[1]);
-
-        model_part.CreateNewElement(15, CoSimIO::ElementType::Point2D, {node_ids[0]});
-        model_part.CreateNewElement(73, CoSimIO::ElementType::Line2D2, {node_ids[1], node_ids[2]});
-        model_part.CreateNewElement(47, CoSimIO::ElementType::Triangle3D3, {node_ids[1], node_ids[2], node_ids[0]});
-    }
-
-    std::stringstream test_stream;
-    model_part.Save(test_stream);
-
     ModelPart loaded_model_part("xxx");
-    loaded_model_part.Load(test_stream);
+
+    const int node_ids[] = {2, 159, 61};
+    const std::array<double, 3> node_coords = {1.0, -2.7, 9.44};
+    model_part.CreateNewNode(node_ids[0], node_coords[0], node_coords[1], node_coords[2]);
+    model_part.CreateNewNode(node_ids[1], node_coords[1], node_coords[2], node_coords[0]);
+    model_part.CreateNewNode(node_ids[2], node_coords[2], node_coords[0], node_coords[1]);
+
+    model_part.CreateNewElement(15, CoSimIO::ElementType::Point2D, {node_ids[0]});
+    model_part.CreateNewElement(73, CoSimIO::ElementType::Line2D2, {node_ids[1], node_ids[2]});
+    model_part.CreateNewElement(47, CoSimIO::ElementType::Triangle3D3, {node_ids[1], node_ids[2], node_ids[0]});
+
+    SUBCASE("ascii")
+    {
+        std::stringstream test_stream;
+        model_part.Save(test_stream, StreamMode::ASCII);
+        loaded_model_part.Load(test_stream, StreamMode::ASCII);
+    }
+
+    SUBCASE("binary")
+    {
+        std::stringstream test_stream;
+        model_part.Save(test_stream, StreamMode::BINARY);
+        loaded_model_part.Load(test_stream, StreamMode::BINARY);
+    }
 
     CheckModelPartsAreEqual(model_part, loaded_model_part);
 }

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -469,7 +469,7 @@ TEST_CASE("model_part_save_load")
 
     SUBCASE("binary")
     {
-        std::stringstream test_stream;
+        std::stringstream test_stream(std::ios_base::in | std::ios_base::out | std::ios::binary);
         model_part.Save(test_stream, StreamMode::BINARY);
         loaded_model_part.Load(test_stream, StreamMode::BINARY);
     }

--- a/tests/co_sim_io/impl/test_model_part.cpp
+++ b/tests/co_sim_io/impl/test_model_part.cpp
@@ -80,6 +80,26 @@ TEST_CASE("node_ostream")
     CHECK_EQ(test_stream.str(), exp_string);
 }
 
+TEST_CASE("node_save_load")
+{
+    Node node(85, 0.2, -33.4, 647);
+    Node loaded_node(1, 0,0,0);
+
+    std::stringstream test_stream;
+
+    node.Save(test_stream);
+
+    std::cerr << "Node save: " << test_stream.str();
+
+    loaded_node.Load(test_stream);
+
+    CHECK_EQ(node.Id(), loaded_node.Id());
+
+    CHECK_EQ(node.X(), doctest::Approx(loaded_node.X()));
+    CHECK_EQ(node.Y(), doctest::Approx(loaded_node.Y()));
+    CHECK_EQ(node.Z(), doctest::Approx(loaded_node.Z()));
+}
+
 TEST_CASE("element_basics")
 {
     const int id = 33;


### PR DESCRIPTION
This adds serialization for `DataContainer` & `ModelPart`

Esp for the `ModelPart` I think we will get back to again later when we switch to Intrusive pointers

very interesting: https://isocpp.org/wiki/faq/serialization