### PR TITLE
[MPI] adding C++ interface

### DIFF
--- a/co_sim_io/co_sim_io.hpp
+++ b/co_sim_io/co_sim_io.hpp
@@ -36,6 +36,11 @@ Note that this introduces dependencies such as e.g. boost (header-only version) 
 #include "impl/info.hpp"
 #include "impl/model_part.hpp"
 
+// include the MPI extension if necessary
+#ifdef CO_SIM_IO_USING_MPI
+#include "impl/mpi/co_sim_io_mpi.hpp"
+#endif
+
 namespace CoSimIO {
 
 inline Info Hello();

--- a/co_sim_io/impl/mpi/co_sim_io_mpi.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi.hpp
@@ -21,8 +21,8 @@ This file contains the interface of the MPI extension for the CoSimIO
 #include "mpi.h"
 
 // Project includes
-#include "impl/define.hpp"
-#include "impl/info.hpp"
+#include "../define.hpp"
+#include "../info.hpp"
 
 namespace CoSimIO {
 

--- a/co_sim_io/impl/mpi/co_sim_io_mpi.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi.hpp
@@ -1,0 +1,39 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef CO_SIM_IO_MPI_INCLUDED
+#define CO_SIM_IO_MPI_INCLUDED
+
+/*
+This file contains the interface of the MPI extension for the CoSimIO
+*/
+
+// System includes
+#include "mpi.h"
+
+// Project includes
+#include "impl/define.hpp"
+#include "impl/info.hpp"
+
+namespace CoSimIO {
+
+
+inline Info ConnectMPI(
+    const Info& I_Settings,
+    MPI_Comm ThisMPIComm);
+
+
+} // namespace CoSimIO
+
+#include "co_sim_io_mpi_impl.hpp"
+
+#endif // CO_SIM_IO_MPI_INCLUDED

--- a/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
@@ -1,0 +1,40 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef CO_SIM_IO_MPI_IMPL_INCLUDED
+#define CO_SIM_IO_MPI_IMPL_INCLUDED
+
+/*
+This file contains the implementation of the functions defined in "co_sim_io_mpi.hpp"
+*/
+
+// System includes
+#include "mpi.h"
+
+// Project includes
+#include "impl/define.hpp"
+#include "impl/info.hpp"
+
+namespace CoSimIO {
+
+inline Info ConnectMPI(
+    const Info& I_Settings,
+    MPI_Comm ThisMPIComm)
+{
+    CO_SIM_IO_ERROR << "Not implemented!" << std::endl;
+}
+
+} // namespace CoSimIO
+
+#include "impl/co_sim_io_impl.hpp"
+
+#endif // CO_SIM_IO_MPI_IMPL_INCLUDED

--- a/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
@@ -36,6 +36,8 @@ inline Info ConnectMPI(
     int flag_initialized;
     MPI_Initialized(&flag_initialized);
     CO_SIM_IO_ERROR_IF_NOT(flag_initialized) << "MPI must be initialized before calling \"ConnectMPI\"!" << std::endl;
+
+    return Info(); // TODO use this
 }
 
 } // namespace CoSimIO

--- a/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
@@ -31,6 +31,11 @@ inline Info ConnectMPI(
     MPI_Comm ThisMPIComm)
 {
     CO_SIM_IO_ERROR << "Not implemented!" << std::endl;
+
+    // make sure MPI was already initialized by the host
+    int flag_initialized;
+    MPI_Initialized(&flag_initialized);
+    CO_SIM_IO_ERROR_IF_NOT(flag_initialized) << "MPI must be initialized before calling \"ConnectMPI\"!" << std::endl;
 }
 
 } // namespace CoSimIO

--- a/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
+++ b/co_sim_io/impl/mpi/co_sim_io_mpi_impl.hpp
@@ -21,8 +21,8 @@ This file contains the implementation of the functions defined in "co_sim_io_mpi
 #include "mpi.h"
 
 // Project includes
-#include "impl/define.hpp"
-#include "impl/info.hpp"
+#include "../define.hpp"
+#include "../info.hpp"
 
 namespace CoSimIO {
 
@@ -34,7 +34,5 @@ inline Info ConnectMPI(
 }
 
 } // namespace CoSimIO
-
-#include "impl/co_sim_io_impl.hpp"
 
 #endif // CO_SIM_IO_MPI_IMPL_INCLUDED

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ set_target_properties(co_sim_io_tests PROPERTIES
 
 doctest_discover_tests(co_sim_io_tests)
 
-
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )
     add_executable ( co_sim_io_mpi_tests ${CO_SIM_IO_MPI_TEST_FILES} )
@@ -52,6 +51,23 @@ add_test(NAME import_export_info_cpp_test COMMAND sh run.sh $<TARGET_FILE:export
 add_test(NAME import_export_data_cpp_test COMMAND sh run.sh $<TARGET_FILE:export_data_cpp_test>  $<TARGET_FILE:import_data_cpp_test>)
 add_test(NAME import_export_mesh_cpp_test COMMAND sh run.sh $<TARGET_FILE:export_mesh_cpp_test>  $<TARGET_FILE:import_mesh_cpp_test>)
 add_test(NAME run_runner_cpp_test COMMAND sh run.sh $<TARGET_FILE:run_cpp_test>  $<TARGET_FILE:runner_cpp_test>)
+
+if (CO_SIM_IO_ENABLE_MPI)
+    function(add_cpp_mpi_executable TEST_SOURCE_FILE)
+        get_filename_component(TEST_FILENAME ${TEST_SOURCE_FILE} NAME)
+        string(REGEX REPLACE ".cpp" "_cpp_test" TEST_NAME ${TEST_FILENAME})
+        message(STATUS  "adding ${TEST_NAME} ")
+        add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
+        target_link_libraries(${TEST_NAME} ${MPI_LIBRARIES})
+        install(TARGETS ${TEST_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/bin/tests_cpp_mpi")
+    endfunction()
+
+    file(GLOB cpp_mpi_test_files "integration_tutorials/cpp/mpi/*.cpp")
+
+    foreach(cpp_mpi_test_file ${cpp_mpi_test_files})
+    add_cpp_mpi_executable(${cpp_mpi_test_file})
+    endforeach(cpp_mpi_test_file)
+endif()
 
 ### C tests ###
 if(BUILD_C)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,11 +1,17 @@
 include_directories( ${CMAKE_SOURCE_DIR}/co_sim_io )
 include_directories( ${CMAKE_SOURCE_DIR}/external_libraries )
 
+set (EXTRA_LIBS "")
+
+if (CO_SIM_IO_ENABLE_MPI)
+    set (EXTRA_LIBS ${MPI_LIBRARIES})
+endif()
+
 ### Test runner for tests of CoSimIO
 find_package (Threads REQUIRED)
 file( GLOB CO_SIM_IO_TEST_FILES co_sim_io/impl/*.cpp)
 add_executable ( co_sim_io_tests ${CO_SIM_IO_TEST_FILES})
-target_link_libraries(co_sim_io_tests ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(co_sim_io_tests ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_LIBS})
 install( TARGETS co_sim_io_tests DESTINATION ${CMAKE_SOURCE_DIR}/bin )
 set_target_properties(co_sim_io_tests PROPERTIES
     CXX_STANDARD 11
@@ -36,6 +42,7 @@ function(add_cpp_executable TEST_SOURCE_FILE)
     string(REGEX REPLACE ".cpp" "_cpp_test" TEST_NAME ${TEST_FILENAME})
     message(STATUS  "adding ${TEST_NAME} ")
     add_executable(${TEST_NAME} ${TEST_SOURCE_FILE})
+    target_link_libraries(${TEST_NAME} ${EXTRA_LIBS})
     install(TARGETS ${TEST_NAME} DESTINATION "${CMAKE_SOURCE_DIR}/bin/tests_cpp")
 endfunction()
 

--- a/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_a.cpp
+++ b/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_a.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
     settings.Set("echo_level", 1);
     settings.Set("version", "1.25");
 
-    auto info = CoSimIO::Connect(settings);
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
     COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
     const std::string connection_name = info.Get<std::string>("connection_name");
 

--- a/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_a.cpp
+++ b/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_a.cpp
@@ -1,0 +1,49 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_connect_disconnect_a");
+    settings.Set("connect_to", "cpp_connect_disconnect_b");
+    settings.Set("is_distributed", true);
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::Connect(settings);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_b.cpp
+++ b/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_b.cpp
@@ -1,0 +1,49 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_connect_disconnect_b");
+    settings.Set("connect_to", "cpp_connect_disconnect_a");
+    settings.Set("is_distributed", true);
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::Connect(settings);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_b.cpp
+++ b/tests/integration_tutorials/cpp/mpi/connect_disconnect_mpi_b.cpp
@@ -34,7 +34,7 @@ int main(int argc, char** argv)
     settings.Set("echo_level", 1);
     settings.Set("version", "1.25");
 
-    auto info = CoSimIO::Connect(settings);
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
     COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
     const std::string connection_name = info.Get<std::string>("connection_name");
 


### PR DESCRIPTION
Adding the first version of the C++ interface for MPI

@pooyan-dadvand tbd in the next meeting

One unfortunate thing is that if we are header only we have to link also the serial tests to MPI