### PR TITLE
[C] adding nodiscard for CoSimIO_Info

### DIFF
--- a/co_sim_io/c/co_sim_io_c.h
+++ b/co_sim_io/c/co_sim_io_c.h
@@ -35,29 +35,29 @@ enum CoSimIO_ConnectionStatus
     CoSimIO_DisconnectionError
 };
 
-CoSimIO_Info CoSimIO_Hello();
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_Hello();
 
-CoSimIO_Info CoSimIO_Connect(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_Connect(
     const CoSimIO_Info I_Settings);
 
-CoSimIO_Info CoSimIO_Disconnect(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_Disconnect(
     const CoSimIO_Info I_Info);
 
-CoSimIO_Info CoSimIO_ImportData(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ImportData(
     const CoSimIO_Info I_Info,
     int* O_Size,
     double** O_Data);
 
-CoSimIO_Info CoSimIO_ExportData(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ExportData(
     const CoSimIO_Info I_Info,
     const int I_Size,
     const double* I_Data);
 
-CoSimIO_Info CoSimIO_ImportMesh(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ImportMesh(
     const CoSimIO_Info I_Info,
     CoSimIO_ModelPart O_ModelPart);
 
-CoSimIO_Info CoSimIO_ExportMesh(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ExportMesh(
     const CoSimIO_Info I_Info,
     const CoSimIO_ModelPart I_ModelPart);
 
@@ -65,17 +65,17 @@ CoSimIO_Info CoSimIO_ExportMesh(
 void CoSimIO_PrintInfo(FILE *Stream,
     const CoSimIO_Info I_Info);
 
-CoSimIO_Info CoSimIO_ImportInfo(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ImportInfo(
     const CoSimIO_Info I_Info);
 
-CoSimIO_Info CoSimIO_ExportInfo(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_ExportInfo(
     const CoSimIO_Info I_Info);
 
-CoSimIO_Info CoSimIO_Register(
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_Register(
     const CoSimIO_Info I_Info,
     CoSimIO_Info (*I_FunctionPointer)(const CoSimIO_Info I_Info));
 
-CoSimIO_Info CoSimIO_Run(const CoSimIO_Info I_Info);
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_Run(const CoSimIO_Info I_Info);
 
 void* CoSimIO_Malloc(size_t size);
 

--- a/co_sim_io/c/co_sim_io_c_info.h
+++ b/co_sim_io/c/co_sim_io_c_info.h
@@ -14,7 +14,9 @@
 #define CO_SIM_IO_C_INFO_INCLUDED
 
 
-typedef struct CoSimIO_Info
+#include "define_c.h"
+
+typedef struct CO_SIM_IO_NODISCARD CoSimIO_Info
 {
     void* PtrCppInfo;
 } CoSimIO_Info;

--- a/co_sim_io/c/co_sim_io_c_info.h
+++ b/co_sim_io/c/co_sim_io_c_info.h
@@ -16,15 +16,15 @@
 
 #include "define_c.h"
 
-typedef struct CO_SIM_IO_NODISCARD CoSimIO_Info
+typedef struct CoSimIO_Info
 {
     void* PtrCppInfo;
 } CoSimIO_Info;
 
 
-CoSimIO_Info CoSimIO_CreateInfo();
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_CreateInfo();
 
-CoSimIO_Info CoSimIO_CopyInfo(const CoSimIO_Info I_Info);
+CO_SIM_IO_NODISCARD CoSimIO_Info CoSimIO_CopyInfo(const CoSimIO_Info I_Info);
 
 int CoSimIO_FreeInfo(CoSimIO_Info I_Info);
 

--- a/co_sim_io/c/define_c.h
+++ b/co_sim_io/c/define_c.h
@@ -17,7 +17,7 @@
 https://en.cppreference.com/w/c/language/attributes/nodiscard
 hence using custom solution
 */
-#if (defined(__GNUC__) || defined(__clang__)) && !(defined(__INTEL_COMPILER))
+#if defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
 #define CO_SIM_IO_NODISCARD __attribute__((warn_unused_result))
 #else
 #define CO_SIM_IO_NODISCARD

--- a/co_sim_io/c/define_c.h
+++ b/co_sim_io/c/define_c.h
@@ -1,0 +1,26 @@
+/*   ______     _____ _           ________
+    / ____/___ / ___/(_)___ ___  /  _/ __ |
+   / /   / __ \\__ \/ / __ `__ \ / // / / /
+  / /___/ /_/ /__/ / / / / / / // // /_/ /
+  \____/\____/____/_/_/ /_/ /_/___/\____/
+  Kratos CoSimulationApplication
+
+  License:         BSD License, see license.txt
+
+  Main authors:    Philipp Bucher (https://github.com/philbucher)
+*/
+
+#ifndef CO_SIM_IO_C_DEFINE_INCLUDED
+#define CO_SIM_IO_C_DEFINE_INCLUDED
+
+/*nodiscard is part of C23:
+https://en.cppreference.com/w/c/language/attributes/nodiscard
+hence using custom solution
+*/
+#if defined(__GNUC__) || defined(__clang__)
+#define CO_SIM_IO_NODISCARD __attribute__((warn_unused_result))
+#else
+#define CO_SIM_IO_NODISCARD
+#endif
+
+#endif /* CO_SIM_IO_C_DEFINE_INCLUDED */

--- a/co_sim_io/c/define_c.h
+++ b/co_sim_io/c/define_c.h
@@ -17,7 +17,7 @@
 https://en.cppreference.com/w/c/language/attributes/nodiscard
 hence using custom solution
 */
-#if defined(__GNUC__) || defined(__clang__)
+#if (defined(__GNUC__) || defined(__clang__)) && !(defined(__INTEL_COMPILER))
 #define CO_SIM_IO_NODISCARD __attribute__((warn_unused_result))
 #else
 #define CO_SIM_IO_NODISCARD


### PR DESCRIPTION
I found a way to emulate `nodiscard` in C :) (with GCC and clang)
Apparently it will be added in C23: https://en.cppreference.com/w/c/language/attributes/nodiscard

this is how the warning message looks like:
~~~
home/philipp/software/CoSimIO/tests/integration_tutorials/c/export_mesh.c:87:5: warning: ignoring return value of function declared with 'warn_unused_result' attribute [-Wunused-result]
    CoSimIO_CreateInfo();
~~~

I would say this is better than manually keeping track of the `CoSimIO_Info`, what do you think @pooyan-dadvand ?

Changelog:
~~~
- creating CO_SIM_IO_NODISCARD to warn when memory is leaked from CoSimIO_Info
~~~