### PR TITLE
[Testing] fixing return values in run.sh script

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -47,9 +47,9 @@ foreach(cpp_test_file ${cpp_test_files})
 add_cpp_executable(${cpp_test_file})
 endforeach(cpp_test_file)
 
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/run.sh  $1 & $2)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/run.sh $1\ &\ $2\ &\nwait\ %1\ &&\ wait\ %2)
 
-# checking if the run script return the correct exit codes
+# checking if the "run.sh" script return the correct exit codes
 add_cpp_executable(test_success.cpp)
 add_cpp_executable(test_fail.cpp)
 add_test(NAME test_fail_fail       COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_fail_cpp_test>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -49,6 +49,15 @@ endforeach(cpp_test_file)
 
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/run.sh  $1 & $2)
 
+# checking if the run script return the correct exit codes
+add_cpp_executable(test_success.cpp)
+add_cpp_executable(test_fail.cpp)
+add_test(NAME test_fail_fail       COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_fail_cpp_test>)
+add_test(NAME test_success_fail    COMMAND sh run.sh $<TARGET_FILE:test_success_cpp_test>  $<TARGET_FILE:test_fail_cpp_test>)
+add_test(NAME test_fail_success    COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_success_cpp_test>)
+add_test(NAME test_success_success COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_success_cpp_test>)
+set_tests_properties(test_fail_fail test_success_fail test_fail_success PROPERTIES WILL_FAIL True)
+
 add_test(hello_cpp_test hello_cpp_test)
 add_test(NAME connect_disconnect_cpp_test COMMAND sh run.sh $<TARGET_FILE:connect_disconnect_a_cpp_test>  $<TARGET_FILE:connect_disconnect_b_cpp_test>)
 add_test(NAME import_export_info_cpp_test COMMAND sh run.sh $<TARGET_FILE:export_info_cpp_test>  $<TARGET_FILE:import_info_cpp_test>)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,7 +55,7 @@ add_cpp_executable(test_fail.cpp)
 add_test(NAME test_fail_fail       COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_fail_cpp_test>)
 add_test(NAME test_success_fail    COMMAND sh run.sh $<TARGET_FILE:test_success_cpp_test>  $<TARGET_FILE:test_fail_cpp_test>)
 add_test(NAME test_fail_success    COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_success_cpp_test>)
-add_test(NAME test_success_success COMMAND sh run.sh $<TARGET_FILE:test_fail_cpp_test>  $<TARGET_FILE:test_success_cpp_test>)
+add_test(NAME test_success_success COMMAND sh run.sh $<TARGET_FILE:test_success_cpp_test>  $<TARGET_FILE:test_success_cpp_test>)
 set_tests_properties(test_fail_fail test_success_fail test_fail_success PROPERTIES WILL_FAIL True)
 
 add_test(hello_cpp_test hello_cpp_test)

--- a/tests/test_fail.cpp
+++ b/tests/test_fail.cpp
@@ -1,0 +1,16 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+int main()
+{
+    return 1;
+}

--- a/tests/test_success.cpp
+++ b/tests/test_success.cpp
@@ -1,0 +1,16 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
At the moment the script `run.sh` (which we use to run the coupled examples) returns the return code of the last executed command!
I.e. if the first one fails this is not detected!

This PR fixes this and also adds tests

useful reference:
https://superuser.com/questions/461432/get-exit-code-from-subshells-that-are-running-in-parallel