### PR TITLE
[doc] adding syntax to API documentation

### DIFF
--- a/docs/api_docs/README.md
+++ b/docs/api_docs/README.md
@@ -143,8 +143,7 @@ Instance of `CoSimIO::Info` which contains the following:
 ~~~c++
 CoSimIO::Info info = CoSimIO::ImportData(
     const CoSimIO::Info& I_Info,
-    std::vector<double>& O_Data
-    );
+    std::vector<double>& O_Data);
 ~~~
 
 #### Syntax C
@@ -190,8 +189,7 @@ Instance of `CoSimIO::Info` which contains the following:
 ~~~c++
 CoSimIO::Info info = CoSimIO::ExportData(
     const CoSimIO::Info& I_Info,
-    const std::vector<double>& I_Data
-    );
+    const std::vector<double>& I_Data);
 ~~~
 
 #### Syntax C
@@ -237,8 +235,7 @@ Instance of `CoSimIO::Info` which contains the following:
 ~~~c++
 CoSimIO::Info info = CoSimIO::ImportMesh(
     const CoSimIO::Info& I_Info,
-    CoSimIO::ModelPart& O_ModelPart
-    );
+    CoSimIO::ModelPart& O_ModelPart);
 ~~~
 
 #### Syntax C
@@ -287,8 +284,7 @@ Instance of `CoSimIO::Info` which contains the following:
 ~~~c++
 CoSimIO::Info info = CoSimIO::ExportMesh(
     const CoSimIO::Info& I_Info,
-    const CoSimIO::ModelPart& I_ModelPart
-    );
+    const CoSimIO::ModelPart& I_ModelPart);
 ~~~
 
 #### Syntax C
@@ -334,8 +330,7 @@ Instance of `CoSimIO::Info` which contains the following:
 #### Syntax C++
 ~~~c++
 CoSimIO::Info info = CoSimIO::Run(
-    const CoSimIO::Info& I_Info
-    );
+    const CoSimIO::Info& I_Info);
 ~~~
 
 #### Syntax C
@@ -348,7 +343,7 @@ CoSimIO_Info info = CoSimIO_Run(
 #### Syntax Python
 ~~~py
 info = CoSimIO.Run(
-    CoSimIO.Info I_Info
+    CoSimIO.Info I_Info)
 ~~~
 
 * * *
@@ -390,8 +385,7 @@ Instance of `CoSimIO::Info` which contains the following:
 ~~~c++
 CoSimIO::Info info = CoSimIO::Register(
     const CoSimIO::Info& I_Info,
-    std::function<Info(const Info&)> I_FunctionPointer
-    );
+    std::function<Info(const Info&)> I_FunctionPointer);
 ~~~
 
 #### Syntax C
@@ -406,7 +400,7 @@ CoSimIO_Info info = CoSimIO_Register(
 ~~~py
 info = CoSimIO.Register(
     CoSimIO.Info I_Info,
-    python_function I_FunctionPointer
+    python_function I_FunctionPointer)
 ~~~
 
 * * *

--- a/docs/api_docs/README.md
+++ b/docs/api_docs/README.md
@@ -186,6 +186,30 @@ Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
 
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::ExportData(
+    const CoSimIO::Info& I_Info,
+    const std::vector<double>& I_Data
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_ExportData(
+    const CoSimIO_Info I_Info,
+    const int I_Size,
+    const double* I_Data);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.ExportData(
+    CoSimIO.Info I_Info,
+    CoSimIO.DoubleVector I_Data)
+~~~
+
 * * *
 
 
@@ -208,6 +232,29 @@ Can only be called with an active connection (i.e. after calling `Connect` and b
 Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
+
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::ImportMesh(
+    const CoSimIO::Info& I_Info,
+    CoSimIO::ModelPart& O_ModelPart
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_ImportMesh(
+    const CoSimIO_Info I_Info,
+    CoSimIO_ModelPart O_ModelPart);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.ImportMesh(
+    CoSimIO.Info I_Info,
+    CoSimIO.ModelPart O_ModelPart)
+~~~
 
 
 #### Additional information
@@ -236,6 +283,29 @@ Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
 
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::ExportMesh(
+    const CoSimIO::Info& I_Info,
+    const CoSimIO::ModelPart& I_ModelPart
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_ExportMesh(
+    const CoSimIO_Info I_Info,
+    const CoSimIO_ModelPart I_ModelPart);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.ExportMesh(
+    CoSimIO.Info I_Info,
+    CoSimIO.ModelPart I_ModelPart)
+~~~
+
 
 #### Additional information
 See documentation of `CoSimIO::ModelPart` [here](../model_part/model_part_cpp.md).
@@ -244,7 +314,7 @@ See documentation of `CoSimIO::ModelPart` [here](../model_part/model_part_cpp.md
 
 
 ### Run
-The `Run` method used only for remote controlled CoSimulation. Here the _CoSimulationApplication_ takes full control of the solver / code. Functions for controlling the solver / code have to be registered before using the `Register` function.
+The `Run` method is only for remote controlled CoSimulation. Here the _CoSimulationApplication_ takes full control of the solver / code. Functions for controlling the solver / code have to be registered before using the `Register` function.
 
 #### Requirements
 Can only be called with an active connection (i.e. after calling `Connect` and before calling `Disconnect`).
@@ -260,6 +330,26 @@ Can only be called with an active connection (i.e. after calling `Connect` and b
 Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
+
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::Run(
+    const CoSimIO::Info& I_Info
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_Run(
+    const CoSimIO_Info I_Info);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.Run(
+    CoSimIO.Info I_Info
+~~~
 
 * * *
 
@@ -295,6 +385,29 @@ The following functions can be registered:
 Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
+
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::Register(
+    const CoSimIO::Info& I_Info,
+    std::function<Info(const Info&)> I_FunctionPointer
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_Register(
+    const CoSimIO_Info I_Info,
+    CoSimIO_Info (*I_FunctionPointer)(const CoSimIO_Info I_Info));
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.Register(
+    CoSimIO.Info I_Info,
+    python_function I_FunctionPointer
+~~~
 
 * * *
 

--- a/docs/api_docs/README.md
+++ b/docs/api_docs/README.md
@@ -19,6 +19,22 @@ Instance of `CoSimIO::Info` which contains the following:
 | minor_version | int    | Minor version of _CoSimIO_ |
 | patch_version | string | Patch version of _CoSimIO_ |
 
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::Hello();
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info = CoSimIO_Hello();
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.Hello()
+~~~
+
 * * *
 
 
@@ -38,6 +54,25 @@ Instance of `CoSimIO::Info` which contains the following:
 |---|---|---|
 | connection_name | string | name of connection, necessary for further calls to _CoSimIO_ |
 | connection_status | int | status of the connection, can be used to check if connecting was successful |
+
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::Connect(
+    const CoSimIO::Info& I_Settings);
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_Connect(
+    const CoSimIO_Info I_Settings);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.Connect(
+    CoSimIO.Info I_Settings)
+~~~
 
 * * *
 
@@ -62,6 +97,25 @@ Instance of `CoSimIO::Info` which contains the following:
 |---|---|---|
 | connection_status | int | status of the connection, can be used to check if disconnecting was successful |
 
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::Disconnect(
+    const CoSimIO::Info& I_Info);
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_Disconnect(
+    const CoSimIO_Info I_Info);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.Disconnect(
+    CoSimIO.Info I_Info)
+~~~
+
 * * *
 
 
@@ -84,6 +138,30 @@ Can only be called with an active connection (i.e. after calling `Connect` and b
 Instance of `CoSimIO::Info` which contains the following:
 
 | name | type | description |
+
+#### Syntax C++
+~~~c++
+CoSimIO::Info info = CoSimIO::ImportData(
+    const CoSimIO::Info& I_Info,
+    std::vector<double>& O_Data
+    );
+~~~
+
+#### Syntax C
+~~~c
+CoSimIO_Info info = CoSimIO_ImportData(
+    const CoSimIO_Info I_Info,
+    int* O_Size,
+    double** O_Data);
+~~~
+
+
+#### Syntax Python
+~~~py
+info = CoSimIO.ImportData(
+    CoSimIO.Info I_Info,
+    CoSimIO.DoubleVector O_Data)
+~~~
 
 * * *
 


### PR DESCRIPTION
As discussed @pooyan-dadvand, this adds the syntax for the different languages to the API docs, same as in the MPI docs