### PR TITLE
Fix test WORKING_DIRECTORY

### DIFF
--- a/external_libraries/doctest/doctestAddTests.cmake
+++ b/external_libraries/doctest/doctestAddTests.cmake
@@ -38,6 +38,7 @@ execute_process(
   COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-cases
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
+  WORKING_DIRECTORY "${TEST_WORKING_DIR}"
 )
 if(NOT ${result} EQUAL 0)
   message(FATAL_ERROR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ set_target_properties(co_sim_io_tests PROPERTIES
     CXX_EXTENSIONS NO
 )
 
-doctest_discover_tests(co_sim_io_tests)
+doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )


### PR DESCRIPTION
issue is described here: https://github.com/catchorg/Catch2/pull/2039

In a nutshell: On win the dll is not found

I will also push this upstream