### PR TITLE
[MPI] enable CTest detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,10 @@ jobs:
         fi
 
         cd build
-        ctest -T memcheck --output-on-failure
+        ctest -T memcheck --output-on-failure    
+    
+    - name: print err
+        cat Testing/Temporary/MemoryChecker.58.log
 
 
   Ubuntu-Python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,10 +95,7 @@ jobs:
         fi
 
         cd build
-        ctest -T memcheck --output-on-failure    
-    
-    - name: print err
-        cat Testing/Temporary/MemoryChecker.58.log
+        ctest -T memcheck --output-on-failure
 
     - uses: actions/upload-artifact@v2
       if: failure()

--- a/external_libraries/doctest/doctest.cmake
+++ b/external_libraries/doctest/doctest.cmake
@@ -106,7 +106,7 @@ function(doctest_discover_tests TARGET)
     ""
     ""
     "TEST_PREFIX;TEST_SUFFIX;WORKING_DIRECTORY;TEST_LIST;JUNIT_OUTPUT_DIR"
-    "TEST_SPEC;EXTRA_ARGS;PROPERTIES"
+    "TEST_SPEC;EXTRA_ARGS;PROPERTIES;TEST_EXECUTOR;TEST_EXECUTOR_ARGS"
     ${ARGN}
   )
 
@@ -124,17 +124,18 @@ function(doctest_discover_tests TARGET)
   # Define rule to generate test list for aforementioned test executable
   set(ctest_include_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_include-${args_hash}.cmake")
   set(ctest_tests_file "${CMAKE_CURRENT_BINARY_DIR}/${TARGET}_tests-${args_hash}.cmake")
-  get_property(crosscompiling_emulator
-    TARGET ${TARGET}
-    PROPERTY CROSSCOMPILING_EMULATOR
-  )
+  # get_property(crosscompiling_emulator
+  #   TARGET ${TARGET}
+  #   PROPERTY CROSSCOMPILING_EMULATOR
+  # )
   add_custom_command(
     TARGET ${TARGET} POST_BUILD
     BYPRODUCTS "${ctest_tests_file}"
     COMMAND "${CMAKE_COMMAND}"
             -D "TEST_TARGET=${TARGET}"
             -D "TEST_EXECUTABLE=$<TARGET_FILE:${TARGET}>"
-            -D "TEST_EXECUTOR=${crosscompiling_emulator}"
+            -D "TEST_EXECUTOR=${_TEST_EXECUTOR}"
+            -D "TEST_EXECUTOR_ARGS=${_TEST_EXECUTOR_ARGS}"
             -D "TEST_WORKING_DIR=${_WORKING_DIRECTORY}"
             -D "TEST_SPEC=${_TEST_SPEC}"
             -D "TEST_EXTRA_ARGS=${_EXTRA_ARGS}"

--- a/external_libraries/doctest/doctestAddTests.cmake
+++ b/external_libraries/doctest/doctestAddTests.cmake
@@ -35,7 +35,7 @@ if("${spec}" MATCHES .)
 endif()
 
 execute_process(
-  COMMAND ${TEST_EXECUTOR} "${TEST_EXECUTABLE}" ${spec} --list-test-cases
+  COMMAND "${TEST_EXECUTABLE}" ${spec} --list-test-cases
   OUTPUT_VARIABLE output
   RESULT_VARIABLE result
   WORKING_DIRECTORY "${TEST_WORKING_DIR}"
@@ -68,7 +68,8 @@ foreach(line ${output})
   # ...and add to script
   add_command(add_test
     "${prefix}${test}${suffix}"
-    ${TEST_EXECUTOR}
+    "${TEST_EXECUTOR}"
+    ${TEST_EXECUTOR_ARGS}
     "${TEST_EXECUTABLE}"
     "--test-case=${test_name}"
     "${TEST_JUNIT_OUTPUT_PARAM}"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ if (CO_SIM_IO_ENABLE_MPI)
         CXX_EXTENSIONS NO
     )
 
-    doctest_discover_tests(co_sim_io_mpi_tests TEST_PREFIX "cpp_mpi_" WORKING_DIRECTORY ${CMAKE_BINARY_DIR} TEST_EXECUTOR mpiexec TEST_EXECUTOR_ARGS -np 4)
+    doctest_discover_tests(co_sim_io_mpi_tests TEST_PREFIX "cpp_mpi_" WORKING_DIRECTORY $<TARGET_FILE_DIR:co_sim_io_mpi> TEST_EXECUTOR mpiexec TEST_EXECUTOR_ARGS -np 4)
 
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(co_sim_io_tests PROPERTIES
 )
 
 
-doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+doctest_discover_tests(co_sim_io_tests TEST_PREFIX "cpp_" WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )
@@ -28,7 +28,7 @@ if (CO_SIM_IO_ENABLE_MPI)
         CXX_EXTENSIONS NO
     )
 
-    add_test(NAME "MPI-C++-tests-4-Cores" COMMAND mpiexec -np 4 co_sim_io_mpi_tests)
+    doctest_discover_tests(co_sim_io_mpi_tests TEST_PREFIX "cpp_mpi_" WORKING_DIRECTORY ${CMAKE_BINARY_DIR} TEST_EXECUTOR mpiexec TEST_EXECUTOR_ARGS -np 4)
 
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(co_sim_io_tests PROPERTIES
 )
 
 
-doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY $<TARGET_FILE_DIR:co_sim_io>)
+doctest_discover_tests(co_sim_io_tests TEST_PREFIX "cpp_" WORKING_DIRECTORY $<TARGET_FILE_DIR:co_sim_io>)
 
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )


### PR DESCRIPTION
now the tests are listed as individual tests instead of adding the entire test runner
I.e. now it is consistent with the non-MPI tests :D

I will try to push the changes in doctest also upstream