### PR TITLE
[Testing] generator expression for location of shared lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,9 +240,6 @@ jobs:
     - name: Build CoSimIO
       shell: cmd
       run: |
-        rem adding this to path is currently needed as co_sim_io must be available at configure time for discovering the tests for CTest
-        set PATH=%PATH%;%GITHUB_WORKSPACE%/build/Debug
-
         call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :error
 
         set CC=cl.exe
@@ -296,9 +293,6 @@ jobs:
     - name: Build CoSimIO
       shell: cmd
       run: |
-        rem adding this to path is currently needed as co_sim_io must be available at configure time for discovering the tests for CTest
-        set PATH=%PATH%;%GITHUB_WORKSPACE%/build/Debug
-
         call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :error
 
         set CC=cl.exe

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(co_sim_io_tests PROPERTIES
 )
 
 
-doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY $<TARGET_FILE:co_sim_io>)
 
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,7 @@ set_target_properties(co_sim_io_tests PROPERTIES
 )
 
 
-doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY $<TARGET_FILE:co_sim_io>)
+doctest_discover_tests(co_sim_io_tests WORKING_DIRECTORY $<TARGET_FILE_DIR:co_sim_io>)
 
 if (CO_SIM_IO_ENABLE_MPI)
     file( GLOB CO_SIM_IO_MPI_TEST_FILES co_sim_io/impl/mpi/*.cpp )


### PR DESCRIPTION
leftover of #202 

doctest needs to run the test executable to determine the names of the test cases. For this I need to know the location of the shared lib `co_sim_io`

Hopefully this works with the generator expression