### PR TITLE
Fix tests after intel update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       if: failure()
       with:
         name: CTest log
-        path: ${GITHUB_WORKSPACE}/build/Testing/
+        path: ${{ github.workspace }}/build/Testing/
 
 
   Ubuntu-Python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: failure()
       with:
-        name: CTest log
+        name: "CTest Log Ubuntu C++ & C (${{ matrix.compiler }} / ${{ matrix.mpi }})"
         path: ${{ github.workspace }}/build/Testing/
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       if: failure()
       with:
         name: CTest log
-        path: ${GITHUB_WORKSPACE}/build/Testing
+        path: ${GITHUB_WORKSPACE}/build/Testing/
 
 
   Ubuntu-Python:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,12 @@ jobs:
         cd build
         ctest -T memcheck --output-on-failure
 
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: CTest log
+        path: ${GITHUB_WORKSPACE}/build/Testing
+
 
   Ubuntu-Python:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required (VERSION 2.8.6)
 
 # this has to be specified BEFORE including CTest!
 # suppressions file has to be included in the options, as using "MEMORYCHECK_SUPPRESSIONS_FILE" doesn't work on all systems
-set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --track-origins=yes --tool=memcheck --error-exitcode=1 --suppressions=${CMAKE_SOURCE_DIR}/tests/valgrind_suppressions.supp")
+set(MEMORYCHECK_COMMAND_OPTIONS "--leak-check=full --show-leak-kinds=all --track-origins=yes --tool=memcheck --error-exitcode=1 --suppressions=${CMAKE_SOURCE_DIR}/tests/valgrind_suppressions.supp --gen-suppressions=all")
 
 include(CTest)
 

--- a/tests/filter_valgrind_suppressions.py
+++ b/tests/filter_valgrind_suppressions.py
@@ -1,0 +1,33 @@
+num_supps = 0
+suppressions = []
+
+supp_started = False
+current_supp = ""
+
+with open("MemoryChecker.xxx.log") as val_file: # Use file to refer to the file object
+    lines = val_file.readlines()
+    for line in lines:
+        if not line.startswith("=="):
+            current_supp += line
+
+            if line.startswith("{"):
+                num_supps +=1
+                if supp_started:
+                    raise Exception("cannot start twice!")
+                supp_started = True
+
+            elif line.startswith("}"):
+                if not supp_started:
+                    raise Exception("not yet sterted!")
+                suppressions.append(current_supp)
+                supp_started = False
+                current_supp = ""
+
+print(f"Number of suppressions initially: {num_supps}")
+
+suppressions = list(set(suppressions))
+
+print(f"Number of suppressions after removing duplicates: {len(suppressions)}")
+
+with open("cleaned.supp", "w") as val_file: # Use file to refer to the file object
+    val_file.writelines(suppressions)

--- a/tests/valgrind_suppressions.supp
+++ b/tests/valgrind_suppressions.supp
@@ -717,3 +717,10 @@
    obj:*
    obj:*
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Addr32
+   fun:__intel_avx_memmove
+   fun:_ZN7doctest7Context3runEv
+   fun:main
+}

--- a/tests/valgrind_suppressions.supp
+++ b/tests/valgrind_suppressions.supp
@@ -724,3 +724,132 @@
    fun:_ZN7doctest7Context3runEv
    fun:main
 }
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN4llvm14object_creatorINS_2cl10SubCommandEE4callEv
+   fun:_ZNK4llvm17ManagedStaticBase21RegisterManagedStaticEPFPvvEPFvS1_E
+   fun:_ZN12_GLOBAL__N_117CommandLineParser18registerSubCommandEPN4llvm2cl10SubCommandE
+   fun:_ZN4llvm14object_creatorIN12_GLOBAL__N_117CommandLineParserEE4callEv
+   fun:_ZNK4llvm17ManagedStaticBase21RegisterManagedStaticEPFPvvEPFvS1_E
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_Signals.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN4llvm9StringMapIPNS_2cl6OptionENS_15MallocAllocatorEE11try_emplaceIJS3_EEESt4pairINS_17StringMapIteratorIS3_EEbENS_9StringRefEDpOT_
+   fun:_ZN12_GLOBAL__N_117CommandLineParser9addOptionEPN4llvm2cl6OptionEPNS2_10SubCommandE
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_WithColor.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN4llvm14object_creatorINS_2cl10SubCommandEE4callEv
+   fun:_ZNK4llvm17ManagedStaticBase21RegisterManagedStaticEPFPvvEPFvS1_E
+   fun:_ZN4llvm14object_creatorIN12_GLOBAL__N_117CommandLineParserEE4callEv
+   fun:_ZNK4llvm17ManagedStaticBase21RegisterManagedStaticEPFPvvEPFvS1_E
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_Signals.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN4llvm14object_creatorIN12_GLOBAL__N_117CommandLineParserEE4callEv
+   fun:_ZNK4llvm17ManagedStaticBase21RegisterManagedStaticEPFPvvEPFvS1_E
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_Signals.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:calloc
+   fun:_ZN4llvm13StringMapImpl4initEj
+   fun:_ZN4llvm13StringMapImpl15LookupBucketForENS_9StringRefE
+   fun:_ZN4llvm9StringMapIPNS_2cl6OptionENS_15MallocAllocatorEE11try_emplaceIJS3_EEESt4pairINS_17StringMapIteratorIS3_EEbENS_9StringRefEDpOT_
+   fun:_ZN12_GLOBAL__N_117CommandLineParser9addOptionEPN4llvm2cl6OptionEPNS2_10SubCommandE
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_Signals.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   fun:_Znwm
+   fun:_ZN4llvm9StringMapIPNS_2cl6OptionENS_15MallocAllocatorEE11try_emplaceIJS3_EEESt4pairINS_17StringMapIteratorIS3_EEbENS_9StringRefEDpOT_
+   fun:_ZN12_GLOBAL__N_117CommandLineParser9addOptionEPN4llvm2cl6OptionEPNS2_10SubCommandE
+   fun:_ZN4llvm2cl6Option11addArgumentEv
+   fun:_GLOBAL__sub_I_Signals.cpp
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+}
+{
+   <insert_a_suppression_name_here>
+   Memcheck:Cond
+   fun:__intel_sse2_strrchr
+   fun:strrchr
+   fun:init_ap_data
+   fun:_ZN17_INTERNALebd713af3tbb6detail2r112init_dl_dataEv
+   fun:__pthread_once_slow
+   fun:__gthread_once
+   fun:call_once
+   fun:_ZN3tbb6detail2r122init_dynamic_link_dataEv
+   fun:call_init.part.0
+   fun:call_init
+   fun:_dl_init
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:dlopen_doit
+   fun:_dl_catch_exception
+}


### PR DESCRIPTION
The intel compiler was updated yesterday (`2021.2.0` -> `2021.3.0`)

this produces some more valgrind errors, this PR suppresses those too

Also I am uploading the test logs now as artifacts in case they fail, this will make debugging much less painful