### PR TITLE
warding variables in check macros

### DIFF
--- a/tests/co_sim_io/impl/co_sim_io_testing.hpp
+++ b/tests/co_sim_io/impl/co_sim_io_testing.hpp
@@ -18,36 +18,36 @@
 
 // Custom macros
 
-#define CO_SIM_IO_CHECK_VECTOR_NEAR(a, b) {       \
-REQUIRE_EQ(a.size(), b.size());                   \
-for (std::size_t _i=0; _i<a.size(); ++_i) {       \
-   CHECK_MESSAGE(a[_i] == doctest::Approx(b[_i]), \
-   "Mismatch in component: " << _i);              \
-}                                                 \
+#define CO_SIM_IO_CHECK_VECTOR_NEAR(a, b) {           \
+REQUIRE_EQ((a).size(), (b).size());                   \
+for (std::size_t _i=0; _i<(a).size(); ++_i) {         \
+   CHECK_MESSAGE((a)[_i] == doctest::Approx((b)[_i]), \
+   "Mismatch in component: " << _i);                  \
+}                                                     \
 }
 
-#define CO_SIM_IO_CHECK_VECTOR_EQUAL(a, b) {      \
-REQUIRE_EQ(a.size(), b.size());                   \
-for (std::size_t _i=0; _i<a.size(); ++_i) {       \
-   CHECK_MESSAGE(a[_i] == b[_i],                  \
-   "Mismatch in component: " << _i);              \
-}                                                 \
+#define CO_SIM_IO_CHECK_VECTOR_EQUAL(a, b) {          \
+REQUIRE_EQ((a).size(), (b).size());                   \
+for (std::size_t _i=0; _i<(a).size(); ++_i) {         \
+   CHECK_MESSAGE((a)[_i] == (b)[_i],                  \
+   "Mismatch in component: " << _i);                  \
+}                                                     \
 }
 
-#define CO_SIM_IO_CHECK_VECTOR_NEAR_SIZE(a, b, s) { \
-REQUIRE_GE(a.size(), s);                            \
-REQUIRE_GE(b.size(), s);                            \
-for (std::size_t _i=0; _i<s; ++_i) {                \
-   CHECK_MESSAGE(a[_i] == doctest::Approx(b[_i]),   \
-   "Mismatch in component: " << _i);                \
-}                                                   \
+#define CO_SIM_IO_CHECK_VECTOR_NEAR_SIZE(a, b, s) {   \
+REQUIRE_GE((a).size(), (s));                          \
+REQUIRE_GE((b).size(), (s));                          \
+for (std::size_t _i=0; _i<(s); ++_i) {                \
+   CHECK_MESSAGE((a)[_i] == doctest::Approx((b)[_i]), \
+   "Mismatch in component: " << _i);                  \
+}                                                     \
 }
 
 #define CO_SIM_IO_CHECK_VECTOR_EQUAL_SIZE(a, b, s) { \
-REQUIRE_GE(a.size(), s);                             \
-REQUIRE_GE(b.size(), s);                             \
-for (std::size_t _i=0; _i<s; ++_i) {                 \
-   CHECK_MESSAGE(a[_i] == b[_i],                     \
+REQUIRE_GE((a).size(), (s));                         \
+REQUIRE_GE((b).size(), (s));                         \
+for (std::size_t _i=0; _i<(s); ++_i) {               \
+   CHECK_MESSAGE((a)[_i] == (b)[_i],                 \
    "Mismatch in component: " << _i);                 \
 }                                                    \
 }


### PR DESCRIPTION
now one can directly pass:
```c++
std::shared_ptr<std::vector<...>> p_vec;
CO_SIM_IO_CHECK_VECTOR_NEAR(*p, ...)
```
before it had to be used as:
```c++
std::shared_ptr<std::vector<...>> p_vec;
CO_SIM_IO_CHECK_VECTOR_NEAR((*p), ...)
```
using it without `()` caused some confusing compiler errors