### PR TITLE
setting WINDOWS_EXPORT_ALL_SYMBOLS only on C-lib directly

### DIFF
--- a/co_sim_io/c/CMakeLists.txt
+++ b/co_sim_io/c/CMakeLists.txt
@@ -1,3 +1,10 @@
+if(WIN32)
+  # To enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to automatically
+  # add export decorators for all classes, structs and functions
+  # see https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html#prop_tgt:WINDOWS_EXPORT_ALL_SYMBOLS
+  cmake_minimum_required(VERSION 3.4)
+endif(WIN32)
+
 message("Configuring CoSimIO for C")
 
 add_library (co_sim_io_c SHARED co_sim_io_c.cpp)

--- a/co_sim_io/c/CMakeLists.txt
+++ b/co_sim_io/c/CMakeLists.txt
@@ -1,5 +1,5 @@
 if(WIN32)
-  # To enable CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS to automatically
+  # To enable WINDOWS_EXPORT_ALL_SYMBOLS to automatically
   # add export decorators for all classes, structs and functions
   # see https://cmake.org/cmake/help/latest/prop_tgt/WINDOWS_EXPORT_ALL_SYMBOLS.html#prop_tgt:WINDOWS_EXPORT_ALL_SYMBOLS
   cmake_minimum_required(VERSION 3.4)

--- a/co_sim_io/c/CMakeLists.txt
+++ b/co_sim_io/c/CMakeLists.txt
@@ -1,10 +1,7 @@
 message("Configuring CoSimIO for C")
 
-# generate_export_header support for C project was added in CMake 3.12
-# hence lets use this for now
-set( CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON )
-
 add_library (co_sim_io_c SHARED co_sim_io_c.cpp)
+set_target_properties(co_sim_io_c PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 
 target_link_libraries( co_sim_io_c co_sim_io )
 


### PR DESCRIPTION
and not globally

simplification of #216