### PR TITLE
[DataContainer] improve serialization

### DIFF
--- a/co_sim_io/impl/data_container.hpp
+++ b/co_sim_io/impl/data_container.hpp
@@ -60,8 +60,26 @@ public:
 private:
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const {}
-    virtual void load(Serializer& rSerializer) {}
+    virtual void save(Serializer& rSerializer) const
+    {
+        rSerializer.save("size", size());
+        for (std::size_t i=0; i<size(); ++i) {
+            rSerializer.save("v", data()[i]);
+        }
+    }
+
+    virtual void load(Serializer& rSerializer)
+    {
+        std::size_t new_size;
+        rSerializer.load("size", new_size);
+        if (size() != new_size) {
+            resize(new_size);
+        }
+
+        for (std::size_t i=0; i<size(); ++i) {
+            rSerializer.load("v", data()[i]);
+        }
+    }
 };
 
 /// output stream function
@@ -102,13 +120,11 @@ private:
     void save(Serializer& rSerializer) const override
     {
         CO_SIM_IO_SERIALIZE_SAVE_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        rSerializer.save("mrVector", mrVector);
     }
 
     void load(Serializer& rSerializer) override
     {
         CO_SIM_IO_SERIALIZE_LOAD_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        rSerializer.load("mrVector", mrVector);
     }
 };
 
@@ -132,7 +148,6 @@ private:
     void save(Serializer& rSerializer) const override
     {
         CO_SIM_IO_SERIALIZE_SAVE_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        rSerializer.save("mrVector", mrVector);
     }
 
     void load(Serializer& rSerializer) override {CO_SIM_IO_ERROR << "Loading a readonly object is not possible!" << std::endl;}
@@ -174,24 +189,11 @@ private:
     void save(Serializer& rSerializer) const override
     {
         CO_SIM_IO_SERIALIZE_SAVE_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        rSerializer.save("mSize", mSize);
-        for (std::size_t i=0; i<mSize; ++i) {
-            rSerializer.save("v"+std::to_string(i), data()[i]);
-        }
     }
 
     void load(Serializer& rSerializer) override
     {
         CO_SIM_IO_SERIALIZE_LOAD_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        std::size_t new_size;
-        rSerializer.load("mSize", new_size);
-        if (mSize != new_size) {
-            resize(new_size);
-        }
-
-        for (std::size_t i=0; i<mSize; ++i) {
-            rSerializer.load("v"+std::to_string(i), data()[i]);
-        }
     }
 };
 
@@ -216,10 +218,6 @@ private:
     void save(Serializer& rSerializer) const override
     {
         CO_SIM_IO_SERIALIZE_SAVE_BASE_CLASS(rSerializer, DataContainer<TDataType>)
-        rSerializer.save("mSize", mSize);
-        for (std::size_t i=0; i<mSize; ++i) {
-            rSerializer.save("v"+std::to_string(i), data()[i]);
-        }
     }
 
     void load(Serializer& rSerializer) override {CO_SIM_IO_ERROR << "Loading a readonly object is not possible!" << std::endl;}

--- a/tests/co_sim_io/impl/test_data_container.cpp
+++ b/tests/co_sim_io/impl/test_data_container.cpp
@@ -292,8 +292,6 @@ TEST_CASE("DataContainer_serialization_RawMemory")
 
     const std::size_t cur_size(ref_values.size());
 
-    std::vector<double> load_values;
-
     DataContainerBasePointer p_save_container;
 
     double** values_raw = (double**)malloc(sizeof(double*)*1);
@@ -327,6 +325,31 @@ TEST_CASE("DataContainer_serialization_RawMemory")
     // deallocating memory
     free(*values_raw);
     free(values_raw);
+    free(load_data);
+}
+
+TEST_CASE("DataContainer_serialization_mixed")
+{
+    std::vector<double> ref_values {
+        1.0, -2.333, 15.88, 14.7, -99.6
+    };
+
+    const DataContainerBasePointer p_save_container(CoSimIO::make_unique<DataContainerStdVectorReadOnly<double>>(ref_values));
+
+    const DataContainerBase& const_ref_save = *p_save_container;
+
+    double* load_data;
+    DataContainerBasePointer p_load_container(CoSimIO::make_unique<DataContainerRawMemoryType>(&load_data, 0));
+
+    DataContainerBase& ref_load = *p_load_container;
+
+    CoSimIO::Internals::StreamSerializer serializer;
+    serializer.save("container", const_ref_save);
+    serializer.load("container", ref_load);
+
+    CO_SIM_IO_CHECK_VECTOR_NEAR(const_ref_save, ref_load);
+
+    // deallocating memory
     free(load_data);
 }
 


### PR DESCRIPTION
the behavior needs to be the same so that we can serialize to and from different types
necessary e.g. when going from C (raw memory based) to Python (std::vector based)