### PR TITLE
adding macro detection for Win

### DIFF
--- a/co_sim_io/includes/define.hpp
+++ b/co_sim_io/includes/define.hpp
@@ -101,6 +101,11 @@ intrusive_ptr<C> make_intrusive(Args &&...args) {
     return intrusive_ptr<C>(new C(std::forward<Args>(args)...));
 }
 
+// OS detection
+#if defined(_WIN32)
+    #define CO_SIM_IO_COMPILED_IN_WINDOWS
+#endif
+
 // Logging macros
 #define CO_SIM_IO_INFO(label) std::cout << label << ": "
 #define CO_SIM_IO_INFO_IF(label, conditional) if (conditional) CO_SIM_IO_INFO(label)


### PR DESCRIPTION
needed as some IPC methods are plattform dependent

very basic version, we can easily extend it if necessary