### PR TITLE
[CI] always upload logs of CTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
         ctest -T memcheck --output-on-failure
 
     - uses: actions/upload-artifact@v2
-      if: failure()
       with:
         name: "CTest Log Ubuntu C++ & C (${{ matrix.compiler }} / ${{ matrix.mpi }})"
         path: ${{ github.workspace }}/build/Testing/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
 
     - uses: actions/upload-artifact@v2
       with:
-        name: "CTest Log Ubuntu C++ & C (${{ matrix.compiler }} / ${{ matrix.mpi }})"
+        name: "CTest Log Ubuntu C++ & C (${{ matrix.compiler }}-${{ matrix.mpi }})"
         path: ${{ github.workspace }}/build/Testing/
 
 

--- a/tests/co_sim_io/c/info/test_info_double.c
+++ b/tests/co_sim_io/c/info/test_info_double.c
@@ -30,6 +30,7 @@ int main()
 
     COSIMIO_CHECK_DOUBLE_EQUAL(CoSimIO_Info_GetDouble(info, "tolerance"), 0.0086);
 
-
+    CoSimIO_FreeInfo(info);
+    
     return 0;
 }

--- a/tests/co_sim_io/c/info/test_info_double.c
+++ b/tests/co_sim_io/c/info/test_info_double.c
@@ -30,7 +30,7 @@ int main()
 
     COSIMIO_CHECK_DOUBLE_EQUAL(CoSimIO_Info_GetDouble(info, "tolerance"), 0.0086);
 
-    CoSimIO_FreeInfo(info);
+    // CoSimIO_FreeInfo(info);
 
     return 0;
 }

--- a/tests/co_sim_io/c/info/test_info_double.c
+++ b/tests/co_sim_io/c/info/test_info_double.c
@@ -30,7 +30,6 @@ int main()
 
     COSIMIO_CHECK_DOUBLE_EQUAL(CoSimIO_Info_GetDouble(info, "tolerance"), 0.0086);
 
-    // CoSimIO_FreeInfo(info);
 
     return 0;
 }


### PR DESCRIPTION
when using valgrind, can be useful for debugging