### PR TITLE
adding error code

### DIFF
--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -204,9 +204,10 @@ void Communication::WaitUntilFileIsRemoved(const fs::path& rPath) const
 {
     CO_SIM_IO_TRY
 
-    if (fs::exists(rPath)) { // only issue the wating message if the file exists initially
+    std::error_code ec;
+    if (fs::exists(rPath, ec)) { // only issue the wating message if the file exists initially
         CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>0) << "Waiting for: " << rPath << " to be removed" << std::endl;
-        while(fs::exists(rPath)) {
+        while(fs::exists(rPath, ec)) {
             std::this_thread::sleep_for(std::chrono::milliseconds(5)); // wait 0.001s before next check
         }
         CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>0) << rPath << " was removed" << std::endl;


### PR DESCRIPTION
for some reason the `filesystem::exists` function throws sometimes, guess it crashes when there are race conditions, as the win file access fcts are not atomic by default.

By adding the error code the fct should not crash but populate the error code instead (in which I am not interested)
Lets see if this improves the random errors