### PR TITLE
[Communication] option to use availability file instead of rename

### DIFF
--- a/co_sim_io/includes/communication/communication.hpp
+++ b/co_sim_io/includes/communication/communication.hpp
@@ -108,6 +108,7 @@ private:
 
     fs::path mCommFolder;
     bool mCommInFolder = true;
+    bool mUseAvailFile = false;
 
     fs::path mWorkingDirectory;
     int mEchoLevel = 1;

--- a/co_sim_io/includes/communication/communication.hpp
+++ b/co_sim_io/includes/communication/communication.hpp
@@ -108,7 +108,7 @@ private:
 
     fs::path mCommFolder;
     bool mCommInFolder = true;
-    bool mUseAvailFile = false;
+    bool mUseAuxFileForFileAvailability = false;
 
     fs::path mWorkingDirectory;
     int mEchoLevel = 1;

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -29,6 +29,7 @@ Communication::Communication(
     : mpDataComm(I_DataComm),
       mMyName(I_Settings.Get<std::string>("my_name")),
       mConnectTo(I_Settings.Get<std::string>("connect_to")),
+      mUseAvailFile(I_Settings.Get<bool>("use_avail_file", false)),
       mWorkingDirectory(I_Settings.Get<std::string>("working_directory", fs::relative(fs::current_path()).string())),
       mEchoLevel(I_Settings.Get<int>("echo_level", 0)),
       mPrintTiming(I_Settings.Get<bool>("print_timing", false))

--- a/tests/co_sim_io/cpp/test_communication.cpp
+++ b/tests/co_sim_io/cpp/test_communication.cpp
@@ -20,6 +20,9 @@
 #include "co_sim_io_testing.hpp"
 #include "includes/communication/communication.hpp"
 
+#include "includes/communication/file_communication.hpp"
+#include "includes/communication/sockets_communication.hpp"
+
 namespace {
 
 using CoSimIO::ElementType;
@@ -328,10 +331,9 @@ void ExportMeshHelper(const std::vector<std::shared_ptr<CoSimIO::ModelPart>>& Mo
 }
 
 // neither of the tests should take more than 5.0 seconds. If it does it means that it hangs!
-TEST_CASE_TEMPLATE_DEFINE("Communication"* doctest::timeout(25.0), TCommType, COMM_TESTS)
+template<class TCommType>
+void RunAllCommunication(CoSimIO::Info settings)
 {
-    CoSimIO::Info settings;
-
     settings.Set<std::string>("my_name", "main");
     settings.Set<std::string>("connect_to", "thread");
     settings.Set<bool>("is_primary_connection", true);
@@ -546,14 +548,12 @@ TEST_CASE_TEMPLATE_DEFINE("Communication"* doctest::timeout(25.0), TCommType, CO
     }
 }
 
-// Registering tests for different types of Communication
-#include "includes/communication/file_communication.hpp"
-using FileCommunication = CoSimIO::Internals::FileCommunication;
-TYPE_TO_STRING(FileCommunication);
 
-TEST_CASE_TEMPLATE_INVOKE(COMM_TESTS, FileCommunication);
+TEST_SUITE("Communication") {
 
-#include "includes/communication/sockets_communication.hpp"
-using SocketsCommunication = CoSimIO::Internals::SocketsCommunication;
-TYPE_TO_STRING(SocketsCommunication);
-// TEST_CASE_TEMPLATE_INVOKE(COMM_TESTS, SocketsCommunication);
+TEST_CASE("FileCommunication_default_settings" * doctest::timeout(25.0))
+{
+    RunAllCommunication<CoSimIO::Internals::FileCommunication>(CoSimIO::Info());
+}
+
+} // TEST_SUITE("Communication")

--- a/tests/co_sim_io/cpp/test_communication.cpp
+++ b/tests/co_sim_io/cpp/test_communication.cpp
@@ -557,7 +557,7 @@ TEST_CASE("FileCommunication_default_settings" * doctest::timeout(25.0))
 TEST_CASE("FileCommunication_avail_file" * doctest::timeout(25.0))
 {
     CoSimIO::Info settings;
-    settings.Set<bool>("use_avail_file", true);
+    settings.Set<bool>("use_aux_file_for_file_availability", true);
     RunAllCommunication<CoSimIO::Internals::FileCommunication>(settings);
 }
 


### PR DESCRIPTION
As of now for the file communication we create the file with a temp name when writing to it in order to avoid race conditions when accessing it.
E.g. when writing to `data_abc.dat`, the sender writes it in `.data_abc.dat` to hide it from the receiver. Once the writing is done, it is renamed to `data_abc.dat` so that the receiver can see it. Unfortunately on some OSs (e.g. Windows), `rename` is not atomic and race conditions can occur. I implemented several safety mechanisms to prevent this from happening, but it is not impossible to happen.

Hence this PR introduces a new method to solve this problem: Instead of renaming the file, an auxiliary file is written, which indicates that the original file is ready to be read.
It seems to work well, we have to see how it behaves in practice

I also took the chance to refactor the communication tests to include tests with different settings