### PR TITLE
[FileComm] making MPI compatible

### DIFF
--- a/co_sim_io/includes/communication/communication.hpp
+++ b/co_sim_io/includes/communication/communication.hpp
@@ -85,6 +85,7 @@ protected:
     bool GetIsPrimaryConnection() const        {return mIsPrimaryConnection;}
     bool GetPrintTiming() const                {return mPrintTiming;}
     bool GetIsConnected() const                {return mIsConnected;}
+    const DataCommunicator& GetDataCommunicator() const                {return *mpDataComm;}
 
     Info GetMyInfo() const;
     Info GetPartnerInfo() const {return mPartnerInfo;};

--- a/co_sim_io/includes/utilities.hpp
+++ b/co_sim_io/includes/utilities.hpp
@@ -16,7 +16,7 @@
 // System includes
 #include <string>
 #include <chrono>
-#include <unordered_set>
+#include <set>
 
 // Project includes
 #include "define.hpp"
@@ -46,12 +46,12 @@ int CO_SIM_IO_API GetNumberOfNodesForElementType(ElementType Type);
 
 void CO_SIM_IO_API WaitUntilPathExists(const fs::path& rPath);
 
-std::unordered_set<std::size_t> CO_SIM_IO_API ComputePartnerRanksAsImporter(
+std::set<std::size_t> CO_SIM_IO_API ComputePartnerRanksAsImporter(
     const std::size_t MyRank,
     const std::size_t MySize,
     const std::size_t PartnerSize);
 
-std::unordered_set<std::size_t> CO_SIM_IO_API ComputePartnerRanksAsExporter(
+std::set<std::size_t> CO_SIM_IO_API ComputePartnerRanksAsExporter(
     const std::size_t MyRank,
     const std::size_t MySize,
     const std::size_t PartnerSize);

--- a/co_sim_io/sources/communication/file_communication.cpp
+++ b/co_sim_io/sources/communication/file_communication.cpp
@@ -23,7 +23,7 @@ namespace Internals {
 
 namespace {
 
-// Important: having this in a file also makes sure that the FileSerializer releases its resources (i.e. the file) at destruction
+// Important: having this in a function also makes sure that the FileSerializer releases its resources (i.e. the file) at destruction
 template<class TObject>
 void SerializeToFile(const fs::path& rPath, const std::string& rTag, const TObject& rObject, const Serializer::TraceType SerializerTrace)
 {
@@ -35,7 +35,7 @@ void SerializeToFile(const fs::path& rPath, const std::string& rTag, const TObje
     CO_SIM_IO_CATCH
 }
 
-// important: having this in a file also makes sure that the FileSerializer releases its resources (i.e. the file) at destruction
+// important: having this in a function also makes sure that the FileSerializer releases its resources (i.e. the file) at destruction
 template<class TObject>
 void SerializeFromFile(const fs::path& rPath, const std::string& rTag, TObject& rObject, const Serializer::TraceType SerializerTrace)
 {
@@ -141,21 +141,31 @@ Info FileCommunication::ImportDataImpl(
     const std::string identifier = I_Info.Get<std::string>("identifier");
     Utilities::CheckEntry(identifier, "identifier");
 
-    const fs::path file_name(GetFileName("CoSimIO_data_" + GetConnectionName() + "_" + identifier, "dat"));
+    const auto partner_ranks = Utilities::ComputePartnerRanksAsImporter(
+        GetDataCommunicator().Rank(),
+        GetDataCommunicator().Size(),
+        GetPartnerInfo().Get<int>("num_processes")
+    );
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to import array \"" << identifier << "\" in file " << file_name << " ..." << std::endl;
+    CO_SIM_IO_ERROR_IF(partner_ranks.size() > 1) << "Communicating with more than one rank is not yet implemented!" << std::endl;
 
-    WaitForPath(file_name);
+    for (std::size_t partner_rank : partner_ranks) {
+        const fs::path file_name(GetFileName("CoSimIO_data_" + GetConnectionName() + "_" + identifier + "_" + std::to_string(partner_rank), "dat"));
 
-    const auto start_time(std::chrono::steady_clock::now());
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to import array \"" << identifier << "\" in file " << file_name << " ..." << std::endl;
 
-    SerializeFromFile(file_name, "data", rData, Serializer::TraceType::SERIALIZER_NO_TRACE);
+        WaitForPath(file_name);
 
-    RemovePath(file_name);
+        const auto start_time(std::chrono::steady_clock::now());
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished importing array with size: " << rData.size() << std::endl;
+        SerializeFromFile(file_name, "data", rData, Serializer::TraceType::SERIALIZER_NO_TRACE);
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Importing Array \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+        RemovePath(file_name);
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished importing array with size: " << rData.size() << std::endl;
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Importing Array \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+    }
 
     return Info(); // TODO use
 
@@ -171,22 +181,34 @@ Info FileCommunication::ExportDataImpl(
     const std::string identifier = I_Info.Get<std::string>("identifier");
     Utilities::CheckEntry(identifier, "identifier");
 
-    const fs::path file_name(GetFileName("CoSimIO_data_" + GetConnectionName() + "_" + identifier, "dat"));
+    const auto partner_ranks = Utilities::ComputePartnerRanksAsExporter(
+        GetDataCommunicator().Rank(),
+        GetDataCommunicator().Size(),
+        GetPartnerInfo().Get<int>("num_processes")
+    );
 
-    WaitUntilFileIsRemoved(file_name); // TODO maybe this can be queued somehow ... => then it would not block the sender
+    CO_SIM_IO_ERROR_IF(partner_ranks.size() > 1) << "Communicating with more than one rank is not yet implemented!" << std::endl;
 
-    const std::size_t size = rData.size();
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to export array \"" << identifier << "\" with size: " << size << " in file " << file_name << " ..." << std::endl;
+    for (std::size_t partner_rank : partner_ranks) {
+        const fs::path file_name(GetFileName("CoSimIO_data_" + GetConnectionName() + "_" + identifier + "_" + std::to_string(partner_rank), "dat"));
 
-    const auto start_time(std::chrono::steady_clock::now());
+        std::cout << file_name << std::endl;
 
-    SerializeToFile(GetTempFileName(file_name), "data", rData, Serializer::TraceType::SERIALIZER_NO_TRACE);
+        WaitUntilFileIsRemoved(file_name); // TODO maybe this can be queued somehow ... => then it would not block the sender
 
-    MakeFileVisible(file_name);
+        const std::size_t size = rData.size();
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to export array \"" << identifier << "\" with size: " << size << " in file " << file_name << " ..." << std::endl;
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished exporting array" << std::endl;
+        const auto start_time(std::chrono::steady_clock::now());
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Exporting Array \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+        SerializeToFile(GetTempFileName(file_name), "data", rData, Serializer::TraceType::SERIALIZER_NO_TRACE);
+
+        MakeFileVisible(file_name);
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished exporting array" << std::endl;
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Exporting Array \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+    }
 
     return Info(); // TODO use
 
@@ -202,21 +224,31 @@ Info FileCommunication::ImportMeshImpl(
     const std::string identifier = I_Info.Get<std::string>("identifier");
     Utilities::CheckEntry(identifier, "identifier");
 
-    const fs::path file_name(GetFileName("CoSimIO_mesh_" + GetConnectionName() + "_" + identifier, "vtk"));
+    const auto partner_ranks = Utilities::ComputePartnerRanksAsImporter(
+        GetDataCommunicator().Rank(),
+        GetDataCommunicator().Size(),
+        GetPartnerInfo().Get<int>("num_processes")
+    );
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to import mesh \"" << identifier << "\" in file " << file_name << " ..." << std::endl;
+    CO_SIM_IO_ERROR_IF(partner_ranks.size() > 1) << "Communicating with more than one rank is not yet implemented!" << std::endl;
 
-    WaitForPath(file_name);
+    for (std::size_t partner_rank : partner_ranks) {
+        const fs::path file_name(GetFileName("CoSimIO_mesh_" + GetConnectionName() + "_" + identifier + "_" + std::to_string(partner_rank), "vtk"));
 
-    const auto start_time(std::chrono::steady_clock::now());
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to import mesh \"" << identifier << "\" in file " << file_name << " ..." << std::endl;
 
-    SerializeFromFile(file_name, "model_part", O_ModelPart, Serializer::TraceType::SERIALIZER_NO_TRACE);
+        WaitForPath(file_name);
 
-    RemovePath(file_name);
+        const auto start_time(std::chrono::steady_clock::now());
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished importing mesh" << std::endl;
+        SerializeFromFile(file_name, "model_part", O_ModelPart, Serializer::TraceType::SERIALIZER_NO_TRACE);
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Importing Mesh \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+        RemovePath(file_name);
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished importing mesh" << std::endl;
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Importing Mesh \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+    }
 
     return Info(); // TODO use
 
@@ -232,21 +264,31 @@ Info FileCommunication::ExportMeshImpl(
     const std::string identifier = I_Info.Get<std::string>("identifier");
     Utilities::CheckEntry(identifier, "identifier");
 
-    const fs::path file_name(GetFileName("CoSimIO_mesh_" + GetConnectionName() + "_" + identifier, "vtk"));
+    const auto partner_ranks = Utilities::ComputePartnerRanksAsExporter(
+        GetDataCommunicator().Rank(),
+        GetDataCommunicator().Size(),
+        GetPartnerInfo().Get<int>("num_processes")
+    );
 
-    WaitUntilFileIsRemoved(file_name); // TODO maybe this can be queued somehow ... => then it would not block the sender
+    CO_SIM_IO_ERROR_IF(partner_ranks.size() > 1) << "Communicating with more than one rank is not yet implemented!" << std::endl;
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to export mesh \"" << identifier << "\" with " << I_ModelPart.NumberOfNodes() << " Nodes | " << I_ModelPart.NumberOfElements() << " Elements in file " << file_name << " ..." << std::endl;
+    for (std::size_t partner_rank : partner_ranks) {
+        const fs::path file_name(GetFileName("CoSimIO_mesh_" + GetConnectionName() + "_" + identifier + "_" + std::to_string(partner_rank), "vtk"));
 
-    const auto start_time(std::chrono::steady_clock::now());
+        WaitUntilFileIsRemoved(file_name); // TODO maybe this can be queued somehow ... => then it would not block the sender
 
-    SerializeToFile(GetTempFileName(file_name), "model_part", I_ModelPart, Serializer::TraceType::SERIALIZER_NO_TRACE);
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Attempting to export mesh \"" << identifier << "\" with " << I_ModelPart.NumberOfNodes() << " Nodes | " << I_ModelPart.NumberOfElements() << " Elements in file " << file_name << " ..." << std::endl;
 
-    MakeFileVisible(file_name);
+        const auto start_time(std::chrono::steady_clock::now());
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished exporting mesh" << std::endl;
+        SerializeToFile(GetTempFileName(file_name), "model_part", I_ModelPart, Serializer::TraceType::SERIALIZER_NO_TRACE);
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Exporting Mesh \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+        MakeFileVisible(file_name);
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Finished exporting mesh" << std::endl;
+
+        CO_SIM_IO_INFO_IF("CoSimIO", GetPrintTiming()) << "Exporting Mesh \"" << identifier << "\" took: " << Utilities::ElapsedSeconds(start_time) << " [sec]" << std::endl;
+    }
 
     return Info(); // TODO use
 

--- a/co_sim_io/sources/utilities.cpp
+++ b/co_sim_io/sources/utilities.cpp
@@ -96,7 +96,7 @@ void WaitUntilPathExists(const fs::path& rPath)
     while(!fs::exists(rPath)) {std::this_thread::sleep_for(std::chrono::milliseconds(5));} // wait 0.005s before next check
 }
 
-std::unordered_set<std::size_t> ComputePartnerRanksAsImporter(
+std::set<std::size_t> ComputePartnerRanksAsImporter(
     const std::size_t MyRank,
     const std::size_t MySize,
     const std::size_t PartnerSize)
@@ -108,7 +108,7 @@ std::unordered_set<std::size_t> ComputePartnerRanksAsImporter(
 
     if (MySize == 1) {
         // I am serial, communicate with all partner ranks (doesn't matter if partner is distributed or not)
-        std::unordered_set<std::size_t> partner_ranks;
+        std::set<std::size_t> partner_ranks;
         for (std::size_t i=0; i<PartnerSize; ++i) {partner_ranks.insert(i);}
         return partner_ranks;
     } else if (MySize == PartnerSize) {
@@ -124,7 +124,7 @@ std::unordered_set<std::size_t> ComputePartnerRanksAsImporter(
     } else {
         // several of partner ranks communicate with one rank of me
         const std::size_t num_ranks_per_partner_rank = static_cast<std::size_t>(std::ceil(PartnerSize / static_cast<double>(MySize)));
-        std::unordered_set<std::size_t> partner_ranks;
+        std::set<std::size_t> partner_ranks;
         const std::size_t lower_end = MyRank*num_ranks_per_partner_rank;
         const std::size_t upper_end = (MyRank+1)*num_ranks_per_partner_rank;
 
@@ -137,7 +137,7 @@ std::unordered_set<std::size_t> ComputePartnerRanksAsImporter(
     }
 }
 
-std::unordered_set<std::size_t> ComputePartnerRanksAsExporter(
+std::set<std::size_t> ComputePartnerRanksAsExporter(
     const std::size_t MyRank,
     const std::size_t MySize,
     const std::size_t PartnerSize)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,6 +91,10 @@ if (CO_SIM_IO_ENABLE_MPI)
     add_test(NAME connect_disconnect_cpp_serial_mpi_test COMMAND sh run_serial_mpi.sh $<TARGET_FILE:connect_disconnect_a_cpp_test> $<TARGET_FILE:connect_disconnect_mpi_b_cpp_test> 4)
 
     add_test(NAME import_export_info_cpp_mpi_test COMMAND sh run_mpi.sh $<TARGET_FILE:export_info_mpi_cpp_test> $<TARGET_FILE:import_info_mpi_cpp_test> 4 4)
+
+    add_test(NAME import_export_data_cpp_mpi_test COMMAND sh run_mpi.sh $<TARGET_FILE:export_data_mpi_cpp_test> $<TARGET_FILE:import_data_mpi_cpp_test> 4 4)
+
+    add_test(NAME import_export_mesh_cpp_mpi_test COMMAND sh run_mpi.sh $<TARGET_FILE:export_mesh_mpi_cpp_test> $<TARGET_FILE:import_mesh_mpi_cpp_test> 4 4)
 endif()
 
 ### C tests ###

--- a/tests/co_sim_io/cpp/test_utilities.cpp
+++ b/tests/co_sim_io/cpp/test_utilities.cpp
@@ -24,8 +24,8 @@ TEST_SUITE("Utilities") {
 
 TEST_CASE("ComputePartnerRanksAsImporter")
 {
-    std::unordered_set<std::size_t> exp_partner_ranks;
-    std::unordered_set<std::size_t> neighbor_ranks;
+    std::set<std::size_t> exp_partner_ranks;
+    std::set<std::size_t> neighbor_ranks;
 
     SUBCASE("serial_serial")
     {
@@ -525,8 +525,8 @@ TEST_CASE("ComputePartnerRanksAsImporter")
 
 TEST_CASE("ComputePartnerRanksAsExporter")
 {
-    std::unordered_set<std::size_t> exp_partner_ranks;
-    std::unordered_set<std::size_t> neighbor_ranks;
+    std::set<std::size_t> exp_partner_ranks;
+    std::set<std::size_t> neighbor_ranks;
 
     SUBCASE("serial_serial")
     {

--- a/tests/integration_tutorials/cpp/mpi/export_data_mpi.cpp
+++ b/tests/integration_tutorials/cpp/mpi/export_data_mpi.cpp
@@ -1,0 +1,58 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io_mpi.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_export_solver");
+    settings.Set("connect_to", "cpp_import_solver");
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    std::vector<double> data_to_send(rank+5, 3.14*(size+rank));
+    info.Clear();
+    info.Set("identifier", "vector_of_pi");
+    info.Set("connection_name", connection_name);
+    info = CoSimIO::ExportData(info, data_to_send);
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/integration_tutorials/cpp/mpi/export_mesh_mpi.cpp
+++ b/tests/integration_tutorials/cpp/mpi/export_mesh_mpi.cpp
@@ -1,0 +1,91 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+
+// System includes
+#include <vector>
+#include <array>
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io_mpi.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_mesh_export_solver");
+    settings.Set("connect_to", "cpp_mesh_import_solver");
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    // Creating the mesh
+    const std::vector<std::array<double,3>> nodal_coords {
+        {0.0, 2.5, 1.0},
+        {2.0, 0.0, 1.5},
+        {2.0, 2.5, 1.5},
+        {4.0, 2.5, 1.7},
+        {4.0, 0.0, 1.7},
+        {6.0, 0.0, 1.8}
+    };
+
+    const std::vector<CoSimIO::ConnectivitiesType> element_connectivities {
+        {1, 2, 3},
+        {2, 4, 3},
+        {2, 5, 4},
+        {4, 5, 6},
+    };
+
+    CoSimIO::ModelPart model_part("mp_exchange");
+
+    int id_counter=0;
+    for (const auto& coords : nodal_coords) {
+        model_part.CreateNewNode(++id_counter, coords[0], coords[1], coords[2]);
+    }
+
+    id_counter=0;
+    for (const auto& conn : element_connectivities) {
+        model_part.CreateNewElement(++id_counter, CoSimIO::ElementType::Triangle3D3, conn);
+    }
+
+    info.Clear();
+    info.Set("identifier", "fluid_mesh");
+    info.Set("connection_name", connection_name);
+
+    info = CoSimIO::ExportMesh(info, model_part);
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/integration_tutorials/cpp/mpi/import_data_mpi.cpp
+++ b/tests/integration_tutorials/cpp/mpi/import_data_mpi.cpp
@@ -1,0 +1,63 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io_mpi.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_import_solver");
+    settings.Set("connect_to", "cpp_export_solver");
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    std::vector<double> receive_data;
+    info.Clear();
+    info.Set("identifier", "vector_of_pi");
+    info.Set("connection_name", connection_name);
+    info = CoSimIO::ImportData(info, receive_data);
+
+    COSIMIO_CHECK_EQUAL(static_cast<int>(receive_data.size()), rank+5);
+
+    for(auto& value : receive_data)
+        COSIMIO_CHECK_EQUAL(value, 3.14*(size+rank));
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}

--- a/tests/integration_tutorials/cpp/mpi/import_mesh_mpi.cpp
+++ b/tests/integration_tutorials/cpp/mpi/import_mesh_mpi.cpp
@@ -1,0 +1,104 @@
+//     ______     _____ _           ________
+//    / ____/___ / ___/(_)___ ___  /  _/ __ |
+//   / /   / __ \\__ \/ / __ `__ \ / // / / /
+//  / /___/ /_/ /__/ / / / / / / // // /_/ /
+//  \____/\____/____/_/_/ /_/ /_/___/\____/
+//  Kratos CoSimulationApplication
+//
+//  License:         BSD License, see license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+
+// System includes
+#include <vector>
+#include <array>
+
+// External includes
+#include "mpi.h"
+
+// CoSimulation includes
+#include "co_sim_io_mpi.hpp"
+
+#define COSIMIO_CHECK_EQUAL(a, b)                                \
+    if (a != b) {                                                \
+        std::cout << "in line " << __LINE__ << " : " << a        \
+                  << " is not equal to " << b << std::endl;      \
+        return 1;                                                \
+    }
+
+int main(int argc, char** argv)
+{
+    MPI_Init(&argc, &argv);
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    int size;
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    CoSimIO::Info settings;
+    settings.Set("my_name", "cpp_mesh_import_solver");
+    settings.Set("connect_to", "cpp_mesh_export_solver");
+    settings.Set("echo_level", 1);
+    settings.Set("version", "1.25");
+
+    auto info = CoSimIO::ConnectMPI(settings, MPI_COMM_WORLD);
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Connected);
+    const std::string connection_name = info.Get<std::string>("connection_name");
+
+    const std::vector<std::array<double,3>> expected_nodal_coords {
+        {0.0, 2.5, 1.0},
+        {2.0, 0.0, 1.5},
+        {2.0, 2.5, 1.5},
+        {4.0, 2.5, 1.7},
+        {4.0, 0.0, 1.7},
+        {6.0, 0.0, 1.8}
+    };
+
+    const std::vector<CoSimIO::ConnectivitiesType> expected_element_connectivities {
+        {1, 2, 3},
+        {2, 4, 3},
+        {2, 5, 4},
+        {4, 5, 6},
+    };
+
+    info.Clear();
+    info.Set("identifier", "fluid_mesh");
+    info.Set("connection_name", connection_name);
+
+    CoSimIO::ModelPart model_part("mp_exchange");
+
+    info = CoSimIO::ImportMesh(info, model_part);
+
+    COSIMIO_CHECK_EQUAL(model_part.NumberOfNodes(), expected_nodal_coords.size());
+    COSIMIO_CHECK_EQUAL(model_part.NumberOfElements(), expected_element_connectivities.size());
+
+    int counter=0;
+    for (auto node_it=model_part.NodesBegin(); node_it!=model_part.NodesEnd(); ++node_it) {
+        COSIMIO_CHECK_EQUAL((*node_it)->Id(), counter+1);
+        for (std::size_t i=0; i<3; ++i) {
+            COSIMIO_CHECK_EQUAL((*node_it)->Coordinates()[i], expected_nodal_coords[counter][i]);
+        }
+        counter++;
+    }
+
+    counter=0;
+    for (auto elem_it=model_part.ElementsBegin(); elem_it!=model_part.ElementsEnd(); ++elem_it) {
+        COSIMIO_CHECK_EQUAL((*elem_it)->Id(), counter+1);
+        COSIMIO_CHECK_EQUAL(static_cast<int>((*elem_it)->Type()), static_cast<int>(CoSimIO::ElementType::Triangle3D3));
+        COSIMIO_CHECK_EQUAL((*elem_it)->NumberOfNodes(), 3);
+        int node_counter=0;
+        for (auto node_it=(*elem_it)->NodesBegin(); node_it!=(*elem_it)->NodesEnd(); ++node_it) {
+            COSIMIO_CHECK_EQUAL((*node_it)->Id(), expected_element_connectivities[counter][node_counter++]);
+        }
+        counter++;
+    }
+
+    CoSimIO::Info disconnect_settings;
+    disconnect_settings.Set("connection_name", connection_name);
+    info = CoSimIO::Disconnect(disconnect_settings); // disconnect afterwards
+    COSIMIO_CHECK_EQUAL(info.Get<int>("connection_status"), CoSimIO::ConnectionStatus::Disconnected);
+
+    MPI_Finalize();
+
+    return 0;
+}


### PR DESCRIPTION
This PR makes the FileCommunication MPI-compatible
So far it is necessary to use the same number or cores for both sides, this will be improved in a future PR

Some basic tests are added