### PR TITLE
[ModelPart] support for range based loops

### DIFF
--- a/co_sim_io/includes/model_part.hpp
+++ b/co_sim_io/includes/model_part.hpp
@@ -32,6 +32,23 @@ see https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/mod
 
 namespace CoSimIO {
 
+namespace Internals {
+
+template<typename T>
+class PointerVector
+{
+public:
+    PointerVector(const std::vector<T>& rPointerVector) : mPointerVector(rPointerVector) {}
+
+    typename std::vector<T>::const_iterator begin() const {return mPointerVector.begin();}
+    typename std::vector<T>::const_iterator end() const {return mPointerVector.end();}
+
+private:
+    const std::vector<T>& mPointerVector;
+};
+
+} //namespace Internals
+
 class CO_SIM_IO_API Node
 {
 public:
@@ -105,7 +122,8 @@ inline std::ostream & operator <<(
 class CO_SIM_IO_API Element
 {
 public:
-    using NodesContainerType = std::vector<CoSimIO::intrusive_ptr<Node>>;
+    using NodePointerType = CoSimIO::intrusive_ptr<Node>;
+    using NodesContainerType = std::vector<NodePointerType>;
 
     Element(
         const IdType I_Id,
@@ -119,6 +137,7 @@ public:
     IdType Id() const { return mId; }
     ElementType Type() const { return mType; }
     std::size_t NumberOfNodes() const { return mNodes.size(); }
+    const Internals::PointerVector<NodePointerType> Nodes() const {return Internals::PointerVector<NodePointerType>(mNodes);}
     NodesContainerType::const_iterator NodesBegin() const { return mNodes.begin(); }
     NodesContainerType::const_iterator NodesEnd() const { return mNodes.end(); }
 
@@ -170,19 +189,6 @@ class CO_SIM_IO_API ModelPart
 {
 public:
 
-template<typename T>
-class PointerVector
-{
-public:
-    PointerVector(const std::vector<T>& rPointerVector) : mPointerVector(rPointerVector) {}
-
-    typename std::vector<T>::const_iterator begin() const {return mPointerVector.begin();}
-    typename std::vector<T>::const_iterator end() const {return mPointerVector.end();}
-
-private:
-    const std::vector<T>& mPointerVector;
-};
-
     using NodePointerType = CoSimIO::intrusive_ptr<Node>;
     using ElementPointerType = CoSimIO::intrusive_ptr<Element>;
     using NodesContainerType = std::vector<NodePointerType>;
@@ -209,7 +215,8 @@ private:
         const ElementType I_Type,
         const ConnectivitiesType& I_Connectivities);
 
-    const PointerVector<NodePointerType> Nodes() const {return PointerVector<NodePointerType>(mNodes);}
+    const Internals::PointerVector<NodePointerType> Nodes() const {return Internals::PointerVector<NodePointerType>(mNodes);}
+    const Internals::PointerVector<ElementPointerType> Elements() const {return Internals::PointerVector<ElementPointerType>(mElements);}
 
     NodesContainerType::const_iterator NodesBegin() const { return mNodes.begin(); }
     ElementsContainerType::const_iterator ElementsBegin() const { return mElements.begin(); }

--- a/co_sim_io/includes/model_part.hpp
+++ b/co_sim_io/includes/model_part.hpp
@@ -170,6 +170,19 @@ class CO_SIM_IO_API ModelPart
 {
 public:
 
+template<typename T>
+class PointerVector
+{
+public:
+    PointerVector(const std::vector<T>& rPointerVector) : mPointerVector(rPointerVector) {}
+
+    typename std::vector<T>::const_iterator begin() const {return mPointerVector.begin();}
+    typename std::vector<T>::const_iterator end() const {return mPointerVector.end();}
+
+private:
+    const std::vector<T>& mPointerVector;
+};
+
     using NodePointerType = CoSimIO::intrusive_ptr<Node>;
     using ElementPointerType = CoSimIO::intrusive_ptr<Element>;
     using NodesContainerType = std::vector<NodePointerType>;
@@ -195,6 +208,8 @@ public:
         const IdType I_Id,
         const ElementType I_Type,
         const ConnectivitiesType& I_Connectivities);
+
+    const PointerVector<NodePointerType> Nodes() const {return PointerVector<NodePointerType>(mNodes);}
 
     NodesContainerType::const_iterator NodesBegin() const { return mNodes.begin(); }
     ElementsContainerType::const_iterator ElementsBegin() const { return mElements.begin(); }

--- a/co_sim_io/includes/model_part.hpp
+++ b/co_sim_io/includes/model_part.hpp
@@ -34,17 +34,40 @@ namespace CoSimIO {
 
 namespace Internals {
 
-template<typename T>
+template<class TDataType>
 class PointerVector
 {
 public:
-    PointerVector(const std::vector<T>& rPointerVector) : mPointerVector(rPointerVector) {}
 
-    typename std::vector<T>::const_iterator begin() const {return mPointerVector.begin();}
-    typename std::vector<T>::const_iterator end() const {return mPointerVector.end();}
+    using ContainerType = std::vector<TDataType>;
+    using BaseType = typename TDataType::element_type; // to be used with smart pointers
+    using const_iterator_type = typename ContainerType::const_iterator;
+
+	class const_iterator_adaptor : public std::iterator<std::forward_iterator_tag, TDataType>
+	{
+	public:
+		const_iterator_adaptor(const_iterator_type it) : vec_iterator(it) {}
+		const_iterator_adaptor(const const_iterator_adaptor& it) : vec_iterator(it.vec_iterator) {}
+		const_iterator_adaptor& operator++()  { vec_iterator++; return *this; }
+		const_iterator_adaptor operator++(int) { const_iterator_adaptor tmp(*this); operator++(); return tmp; }
+		bool operator==(const const_iterator_adaptor& rhs) const { return vec_iterator == rhs.vec_iterator; }
+		bool operator!=(const const_iterator_adaptor& rhs) const { return vec_iterator != rhs.vec_iterator; }
+		const BaseType& operator*() const { return **(vec_iterator); }
+		// TDataType operator->() const { return *(vec_iterator); }
+		const_iterator_type& base() { return vec_iterator; }
+		const_iterator_type const& base() const { return vec_iterator; }
+
+    private:
+		const_iterator_type vec_iterator;
+	};
+
+    PointerVector(const ContainerType& rPointerVector) : mPointerVector(rPointerVector) {}
+
+    const_iterator_adaptor begin() const {return const_iterator_adaptor(mPointerVector.begin());}
+    const_iterator_adaptor end()   const {return const_iterator_adaptor(mPointerVector.end());}
 
 private:
-    const std::vector<T>& mPointerVector;
+    const ContainerType& mPointerVector;
 };
 
 } //namespace Internals

--- a/tests/co_sim_io/cpp/test_model_part.cpp
+++ b/tests/co_sim_io/cpp/test_model_part.cpp
@@ -176,7 +176,7 @@ TEST_CASE("element_range_based_loop_nodes")
     std::size_t counter=0;
     for (const auto& r_node : element.Nodes()) {
         CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
-        CHECK_EQ(r_node->Id(), node_ids[counter]);
+        CHECK_EQ(r_node.Id(), node_ids[counter]);
         counter++;
     }
 }
@@ -337,7 +337,7 @@ TEST_CASE("model_part_range_based_loop_nodes")
     std::size_t counter = 0;
     for (const auto& r_node : model_part.Nodes()) {
         CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
-        CHECK_EQ(r_node->Id(), counter+1);
+        CHECK_EQ(r_node.Id(), counter+1);
         counter++;
     }
 }
@@ -465,7 +465,7 @@ TEST_CASE("model_part_range_based_loop_elements")
     std::size_t counter = 0;
     for (const auto& r_elem : model_part.Elements()) {
         CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
-        CHECK_EQ(r_elem->Id(), counter+1);
+        CHECK_EQ(r_elem.Id(), counter+1);
         counter++;
     }
 }

--- a/tests/co_sim_io/cpp/test_model_part.cpp
+++ b/tests/co_sim_io/cpp/test_model_part.cpp
@@ -155,6 +155,32 @@ TEST_CASE("element_nodes")
     }
 }
 
+TEST_CASE("element_range_based_loop_nodes")
+{
+    const int id = 33;
+    const CoSimIO::ElementType type = CoSimIO::ElementType::Triangle2D3;
+
+    const int node_ids[] = {2, 159, 61};
+
+    const std::array<double, 3> dummy_coords = {0,0,0};
+    auto p_node_1 = CoSimIO::make_intrusive<CoSimIO::Node>(node_ids[0], dummy_coords);
+    auto p_node_2 = CoSimIO::make_intrusive<CoSimIO::Node>(node_ids[1], dummy_coords);
+    auto p_node_3 = CoSimIO::make_intrusive<CoSimIO::Node>(node_ids[2], dummy_coords);
+
+    Element element(id, type, {p_node_1, p_node_2, p_node_3});
+
+    CHECK_EQ(element.Id(), id);
+    CHECK_EQ(element.Type(), type);
+    CHECK_EQ(element.NumberOfNodes(), 3);
+
+    std::size_t counter=0;
+    for (const auto& r_node : element.Nodes()) {
+        CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
+        CHECK_EQ(r_node->Id(), node_ids[counter]);
+        counter++;
+    }
+}
+
 TEST_CASE("element_ostream")
 {
     const std::array<double, 3> dummy_coords = {0,0,0};
@@ -298,6 +324,24 @@ TEST_CASE("model_part_get_node")
     }
 }
 
+TEST_CASE("model_part_range_based_loop_nodes")
+{
+    ModelPart model_part("for_test");
+
+    for (std::size_t i=0; i<5; ++i) {
+        model_part.CreateNewNode(i+1, 0,0,0);
+    }
+
+    REQUIRE_EQ(model_part.NumberOfNodes(), 5);
+
+    std::size_t counter = 0;
+    for (const auto& r_node : model_part.Nodes()) {
+        CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
+        CHECK_EQ(r_node->Id(), counter+1);
+        counter++;
+    }
+}
+
 TEST_CASE("model_part_create_new_element")
 {
     ModelPart model_part("for_test");
@@ -403,6 +447,26 @@ TEST_CASE("model_part_get_element")
     SUBCASE("non_existing")
     {
         CHECK_THROWS_WITH(model_part.GetElement(elem_id+1), "Error: Element with Id 7 does not exist!\n");
+    }
+}
+
+TEST_CASE("model_part_range_based_loop_elements")
+{
+    ModelPart model_part("for_test");
+
+    model_part.CreateNewNode(1, 0,0,0);
+
+    for (std::size_t i=0; i<4; ++i) {
+        model_part.CreateNewElement(i+1, CoSimIO::ElementType::Point2D, {1});
+    }
+
+    REQUIRE_EQ(model_part.NumberOfElements(), 4);
+
+    std::size_t counter = 0;
+    for (const auto& r_elem : model_part.Elements()) {
+        CAPTURE(counter); // log the current input data (done manually as not fully supported yet by doctest)
+        CHECK_EQ(r_elem->Id(), counter+1);
+        counter++;
     }
 }
 


### PR DESCRIPTION
I find it quite annoying that in order to loop the nodes one has to do:
~~~c++
for (auto node_it=model_part.NodesBegin(); node_it!=model_part.NodesEnd(); ++node_it) {
    (*node_it)->Id()
}
~~~

this PR adds support for range based loops:
~~~c++
for (auto& r_node : model_part.Nodes()) {
    r_node->Id()
    // r_node.Id() // this is done using boost::indirect_iterator in Kratos. 
    // We could implement our own iterator but not sure if it is worth it ...
}
~~~

lets discuss the implementation