### PR TITLE
Adding PartitionType to ModelPart

### DIFF
--- a/co_sim_io/includes/define.hpp
+++ b/co_sim_io/includes/define.hpp
@@ -67,7 +67,7 @@ enum class PartitionType
 {
     Local,
     Ghost
-}
+};
 
 enum class ElementType
 {

--- a/co_sim_io/includes/define.hpp
+++ b/co_sim_io/includes/define.hpp
@@ -63,6 +63,12 @@ enum ConnectionStatus
     DisconnectionError
 };
 
+enum class PartitionType
+{
+    Local,
+    Ghost
+}
+
 enum class ElementType
 {
     Hexahedra3D20,

--- a/co_sim_io/includes/model_part.hpp
+++ b/co_sim_io/includes/model_part.hpp
@@ -57,6 +57,9 @@ public:
     double Z() const { return mZ; }
     CoordinatesType Coordinates() const { return {mX, mY, mZ}; }
 
+    PartitionType GetPartitionType() const { return mPartitionType; }
+    void SetPartitionType(const PartitionType PType) { mPartitionType = PType; }
+
     void Print(std::ostream& rOStream) const;
 
 private:
@@ -64,6 +67,7 @@ private:
     double mX;
     double mY;
     double mZ;
+    PartitionType mPartitionType;
 
     //*********************************************
     //this block is needed for refcounting
@@ -118,6 +122,10 @@ public:
 
     IdType Id() const { return mId; }
     ElementType Type() const { return mType; }
+
+    PartitionType GetPartitionType() const { return mPartitionType; }
+    void SetPartitionType(const PartitionType PType) { mPartitionType = PType; }
+
     std::size_t NumberOfNodes() const { return mNodes.size(); }
     NodesContainerType::const_iterator NodesBegin() const { return mNodes.begin(); }
     NodesContainerType::const_iterator NodesEnd() const { return mNodes.end(); }
@@ -128,6 +136,7 @@ private:
     IdType mId;
     ElementType mType;
     NodesContainerType mNodes;
+    PartitionType mPartitionType;
 
     //*********************************************
     //this block is needed for refcounting


### PR DESCRIPTION
@pooyan-dadvand I am quite sure this is not what you intended but I am not sure how to do it

IMO we need:
- Separation of Local and Ghost entities (both for Nodes AND Elements)
- If we need to loop over either then we will need to store them internally somehow => might require SubModelParts, although I would like to avoid that. We could generate these lists on the fly but will not be cheap ...
- Alternatively we could ask for the partition index, which I think we need in either case. But then we also need access to the `DataCommunicator` in order to tell whether the entity is local or not, which IMO will mess up the structure of CoSimIO a bit...
- In any case I think we also need the Partition Index, I am pretty sure we will need it for sth at some point!
- Also: What is the `InterfaceMesh` in Kratos?
