### PR TITLE
[CI][Python] remove no longer supported versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,7 +208,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", ", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     timeout-minutes: 15
 
     steps:


### PR DESCRIPTION
Python 3.5 and 3.6 are no longer supported on Mac as they reached EOL (python 3.6 will do in 2 months)
also adding 3.10 and using quotes for the version as otherwise is recognized as 3.1