### PR TITLE
Fix pipe comm warnings

### DIFF
--- a/co_sim_io/includes/communication/pipe_communication.hpp
+++ b/co_sim_io/includes/communication/pipe_communication.hpp
@@ -29,14 +29,7 @@ public:
         const Info& I_Settings,
         std::shared_ptr<DataCommunicator> I_DataComm);
 
-    ~PipeCommunication() override
-    {
-        if (GetIsConnected()) {
-            CO_SIM_IO_INFO("CoSimIO") << "Warning: Disconnect was not performed, attempting automatic disconnection!" << std::endl;
-            Info tmp;
-            Disconnect(tmp);
-        }
-    }
+    ~PipeCommunication() override;
 
 private:
 class BidirectionalPipe

--- a/co_sim_io/sources/communication/pipe_communication.cpp
+++ b/co_sim_io/sources/communication/pipe_communication.cpp
@@ -39,6 +39,15 @@ PipeCommunication::PipeCommunication(
 {
 }
 
+PipeCommunication::~PipeCommunication()
+{
+    if (GetIsConnected()) {
+        CO_SIM_IO_INFO("CoSimIO") << "Warning: Disconnect was not performed, attempting automatic disconnection!" << std::endl;
+        Info tmp;
+        Disconnect(tmp);
+    }
+}
+
 Info PipeCommunication::ConnectDetail(const Info& I_Info)
 {
     mpPipe = std::make_shared<BidirectionalPipe>(

--- a/co_sim_io/sources/communication/pipe_communication.cpp
+++ b/co_sim_io/sources/communication/pipe_communication.cpp
@@ -141,7 +141,8 @@ void PipeCommunication::BidirectionalPipe::Write(const std::string& rData)
 {
     #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
     SendSize(rData.size());
-    write(mPipeHandleWrite, rData.c_str(), rData.size());
+    const ssize_t bytes_written = write(mPipeHandleWrite, rData.c_str(), rData.size());
+    CO_SIM_IO_ERROR_IF(bytes_written < 0) << "Error in writing to Pipe!" << std::endl;
     #endif
 }
 
@@ -150,7 +151,8 @@ void PipeCommunication::BidirectionalPipe::Read(std::string& rData)
     #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
     std::size_t received_size = ReceiveSize();
     rData.resize(received_size);
-    read(mPipeHandleRead, &(rData.front()), received_size); // using front as other methods that access the underlying char are const
+    const ssize_t bytes_read = read(mPipeHandleRead, &(rData.front()), received_size); // using front as other methods that access the underlying char are const
+    CO_SIM_IO_ERROR_IF(bytes_read < 0) << "Error in reading from Pipe!" << std::endl;
     #endif
 }
 
@@ -165,7 +167,8 @@ void PipeCommunication::BidirectionalPipe::Close()
 void PipeCommunication::BidirectionalPipe::SendSize(const std::uint64_t Size)
 {
     #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
-    write(mPipeHandleWrite, &Size, sizeof(Size));
+    const ssize_t bytes_written = write(mPipeHandleWrite, &Size, sizeof(Size));
+    CO_SIM_IO_ERROR_IF(bytes_written < 0) << "Error in writing to Pipe!" << std::endl;
     #endif
 }
 
@@ -173,7 +176,8 @@ std::uint64_t PipeCommunication::BidirectionalPipe::ReceiveSize()
 {
     #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
     std::uint64_t imp_size_u;
-    read(mPipeHandleRead, &imp_size_u, sizeof(imp_size_u));
+    const ssize_t bytes_read = read(mPipeHandleRead, &imp_size_u, sizeof(imp_size_u));
+    CO_SIM_IO_ERROR_IF(bytes_read < 0) << "Error in reading from Pipe!" << std::endl;
     return imp_size_u;
     #else
     return 0;


### PR DESCRIPTION
`read` and `write` return a count variable that should not be discarded
Now checking the return value of these fcts

More info see the docs of read and write:
- https://man7.org/linux/man-pages/man2/read.2.html
- https://man7.org/linux/man-pages/man2/write.2.html
