### PR TITLE
Improving SocketComm

### DIFF
--- a/co_sim_io/includes/communication/communication.hpp
+++ b/co_sim_io/includes/communication/communication.hpp
@@ -186,7 +186,7 @@ private:
 
     void HandShake(const Info& I_Info);
 
-    virtual void DerivedHandShake() {};
+    virtual void DerivedHandShake() const {};
 };
 
 } // namespace Internals

--- a/co_sim_io/includes/communication/pipe_communication.hpp
+++ b/co_sim_io/includes/communication/pipe_communication.hpp
@@ -157,7 +157,7 @@ private:
         const Info& I_Info,
         const ModelPart& I_ModelPart) override;
 
-    void DerivedHandShake() override;
+    void DerivedHandShake() const override;
 };
 
 } // namespace Internals

--- a/co_sim_io/includes/communication/socket_communication.hpp
+++ b/co_sim_io/includes/communication/socket_communication.hpp
@@ -113,6 +113,29 @@ private:
         CO_SIM_IO_CATCH
     }
 
+    template<typename TDataType>
+    void Send(const Internals::DataContainer<TDataType>& rData)
+    {
+        CO_SIM_IO_TRY
+
+        SendSize(rData.size());
+        asio::write(*mpAsioSocket, asio::buffer(rData.data(), rData.size()*sizeof(TDataType)));
+
+        CO_SIM_IO_CATCH
+    }
+
+    template<typename TDataType>
+    void Receive(Internals::DataContainer<TDataType>& rData)
+    {
+        CO_SIM_IO_TRY
+
+        std::size_t received_size = ReceiveSize();
+        rData.resize(received_size);
+        asio::read(*mpAsioSocket, asio::buffer(rData.data(), received_size*sizeof(TDataType)));
+
+        CO_SIM_IO_CATCH
+    }
+
     void SendSize(const std::uint64_t Size);
 
     std::uint64_t ReceiveSize();

--- a/co_sim_io/includes/communication/socket_communication.hpp
+++ b/co_sim_io/includes/communication/socket_communication.hpp
@@ -77,6 +77,8 @@ private:
 
     void PrepareConnection(const Info& I_Info) override;
 
+    void DerivedHandShake() const override;
+
     Info GetCommunicationSettings() const override;
 
     void GetPortNumber();
@@ -106,6 +108,8 @@ private:
     void SendSize(const std::uint64_t Size);
 
     std::uint64_t ReceiveSize();
+
+    std::string GetIpAddress() const;
 };
 
 } // namespace Internals

--- a/co_sim_io/includes/communication/socket_communication.hpp
+++ b/co_sim_io/includes/communication/socket_communication.hpp
@@ -71,7 +71,7 @@ private:
     unsigned short mPortNumber=0;
     std::vector<int> mAllPortNumbers;
     std::thread mContextThread;
-
+    std::string mIpAddress;
 
     std::string GetCommunicationName() const override {return "socket";}
 
@@ -90,26 +90,32 @@ private:
     template<class TObjectType>
     void Send(const TObjectType& rObject)
     {
+        CO_SIM_IO_TRY
+
         StreamSerializer serializer;
         serializer.save("object", rObject);
 
         Write(serializer.GetStringRepresentation());
+
+        CO_SIM_IO_CATCH
     }
 
     template<class TObjectType>
     void Receive(TObjectType& rObject)
     {
+        CO_SIM_IO_TRY
+
         std::string buffer;
         Read(buffer);
         StreamSerializer serializer(buffer);
         serializer.load("object", rObject);
+
+        CO_SIM_IO_CATCH
     }
 
     void SendSize(const std::uint64_t Size);
 
     std::uint64_t ReceiveSize();
-
-    std::string GetIpAddress() const;
 };
 
 } // namespace Internals

--- a/co_sim_io/includes/define.hpp
+++ b/co_sim_io/includes/define.hpp
@@ -85,17 +85,21 @@ intrusive_ptr<C> make_intrusive(Args &&...args) {
 }
 
 // OS detection
-#if defined(_WIN32)
+#if defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
+    #define CO_SIM_IO_COMPILED_IN_LINUX
+#elif defined(__APPLE__) && defined(__MACH__)
+    #define CO_SIM_IO_COMPILED_IN_OS
+#elif defined(_WIN32) || defined(_WIN64)
     #define CO_SIM_IO_COMPILED_IN_WINDOWS
 #endif
 
 inline std::string GetOsName()
 {
-#ifdef _WIN32
+#if defined(CO_SIM_IO_COMPILED_IN_WINDOWS)
     return "Windows";
-#elif __APPLE__ || __MACH__
+#elif defined(CO_SIM_IO_COMPILED_IN_OS)
     return "Mac OSX";
-#elif __linux__
+#elif defined(CO_SIM_IO_COMPILED_IN_LINUX)
     return "Linux";
 #else
     return "Other";

--- a/co_sim_io/sources/communication/pipe_communication.cpp
+++ b/co_sim_io/sources/communication/pipe_communication.cpp
@@ -109,7 +109,7 @@ Info PipeCommunication::ExportMeshImpl(
     return Info(); // TODO use
 }
 
-void PipeCommunication::DerivedHandShake()
+void PipeCommunication::DerivedHandShake() const
 {
     CO_SIM_IO_ERROR_IF(GetMyInfo().Get<std::string>("operating_system") != GetPartnerInfo().Get<std::string>("operating_system")) << "Pipe communication cannot be used between different operating systems!" << std::endl;
 }

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -110,7 +110,7 @@ Info SocketCommunication::ConnectDetail(const Info& I_Info)
         mpAsioAcceptor->accept(*mpAsioSocket);
         mpAsioAcceptor->close();
     } else { // this is the client
-        tcp::endpoint my_endpoint(asio::ip::make_address("127.0.0.1"), mPortNumber);
+        tcp::endpoint my_endpoint(asio::ip::make_address(GetIpAddress()), mPortNumber);
         mpAsioSocket->connect(my_endpoint);
     }
 
@@ -139,7 +139,7 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
     // preparing the acceptors to get the ports used for connecting the sockets
     if (GetIsPrimaryConnection()) {
         using namespace asio::ip;
-        tcp::endpoint port_selection_endpoint(asio::ip::make_address("127.0.0.1"), 0);
+        tcp::endpoint port_selection_endpoint(asio::ip::make_address(GetIpAddress()), 0); // using port 0 means that it will look for a free port
         mpAsioAcceptor = std::make_shared<tcp::acceptor>(mAsioContext, port_selection_endpoint);
         mPortNumber = mpAsioAcceptor->local_endpoint().port();
 
@@ -154,6 +154,10 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
         my_ports[0] = mPortNumber;
         r_data_comm.Gather(my_ports, mAllPortNumbers, 0);
     }
+}
+
+void SocketCommunication::DerivedHandShake() const
+{
 }
 
 Info SocketCommunication::GetCommunicationSettings() const
@@ -208,6 +212,11 @@ std::uint64_t SocketCommunication::ReceiveSize()
     std::uint64_t imp_size_u;
     asio::read(*mpAsioSocket, asio::buffer(&imp_size_u, sizeof(imp_size_u)));
     return imp_size_u;
+}
+
+std::string SocketCommunication::GetIpAddress() const
+{
+    return "127.0.0.1";
 }
 
 } // namespace Internals

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -52,6 +52,7 @@ std::unordered_map<std::string, std::string> GetIpv4Addresses()
     std::unordered_map<std::string, std::string> networks;
 
 #ifdef CO_SIM_IO_COMPILED_IN_LINUX
+    // adapted from: https://www.cyberithub.com/list-network-interfaces/
     struct ifaddrs *addresses;
     CO_SIM_IO_ERROR_IF(getifaddrs(&addresses) == -1) << "Available networks could not be determined" << std::endl;
 

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -25,6 +25,8 @@ std::vector<std::string> SplitStringByDelimiter(
 const std::string& rString,
 const char Delimiter)
 {
+    CO_SIM_IO_TRY
+
     std::istringstream ss(rString);
     std::string token;
 
@@ -34,6 +36,23 @@ const char Delimiter)
     }
 
     return splitted_string;
+
+    CO_SIM_IO_CATCH
+}
+
+std::string GetIpAddress(const Info& I_Settings)
+{
+    CO_SIM_IO_TRY
+
+    if (I_Settings.Has("ip_address")) {
+        return I_Settings.Get<std::string>("ip_address");
+    } else if (I_Settings.Has("network_name")) {
+        return "127.0.0.1";
+    } else {
+        return "127.0.0.1"; // local loopback interface
+    }
+
+    CO_SIM_IO_CATCH
 }
 
 } // helpers namespace
@@ -43,64 +62,99 @@ SocketCommunication::SocketCommunication(
     std::shared_ptr<DataCommunicator> I_DataComm)
     : Communication(I_Settings, I_DataComm)
 {
+    CO_SIM_IO_TRY
+
+    mIpAddress = GetIpAddress(I_Settings);
+
+    CO_SIM_IO_CATCH
 }
 
 SocketCommunication::~SocketCommunication()
 {
+    CO_SIM_IO_TRY
+
     if (GetIsConnected()) {
         CO_SIM_IO_INFO("CoSimIO") << "Warning: Disconnect was not performed, attempting automatic disconnection!" << std::endl;
         Info tmp;
         Disconnect(tmp);
     }
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ImportInfoImpl(const Info& I_Info)
 {
+    CO_SIM_IO_TRY
+
     Info imported_info;
     Receive(imported_info);
     return imported_info;
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ExportInfoImpl(const Info& I_Info)
 {
+    CO_SIM_IO_TRY
+
     Send(I_Info);
     return Info(); // TODO use
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ImportDataImpl(
     const Info& I_Info,
     Internals::DataContainer<double>& rData)
 {
+    CO_SIM_IO_TRY
+
     Receive(rData);
     return Info(); // TODO use
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ExportDataImpl(
     const Info& I_Info,
     const Internals::DataContainer<double>& rData)
 {
+    CO_SIM_IO_TRY
+
     Send(rData);
     return Info(); // TODO use
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ImportMeshImpl(
     const Info& I_Info,
     ModelPart& O_ModelPart)
 {
+    CO_SIM_IO_TRY
+
     Receive(O_ModelPart);
     return Info(); // TODO use
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ExportMeshImpl(
     const Info& I_Info,
     const ModelPart& I_ModelPart)
 {
+    CO_SIM_IO_TRY
+
     Send(I_ModelPart);
     return Info(); // TODO use
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::ConnectDetail(const Info& I_Info)
 {
+    CO_SIM_IO_TRY
+
     if (!GetIsPrimaryConnection()) {GetPortNumber();}
 
     using namespace asio::ip;
@@ -110,7 +164,7 @@ Info SocketCommunication::ConnectDetail(const Info& I_Info)
         mpAsioAcceptor->accept(*mpAsioSocket);
         mpAsioAcceptor->close();
     } else { // this is the client
-        tcp::endpoint my_endpoint(asio::ip::make_address(GetIpAddress()), mPortNumber);
+        tcp::endpoint my_endpoint(asio::ip::make_address(mIpAddress), mPortNumber);
         mpAsioSocket->connect(my_endpoint);
     }
 
@@ -118,10 +172,14 @@ Info SocketCommunication::ConnectDetail(const Info& I_Info)
     mContextThread = std::thread([this]() { mAsioContext.run(); });
 
     return Info();
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::DisconnectDetail(const Info& I_Info)
 {
+    CO_SIM_IO_TRY
+
     // Request the context to close
     mAsioContext.stop();
 
@@ -131,19 +189,25 @@ Info SocketCommunication::DisconnectDetail(const Info& I_Info)
     mpAsioSocket->close();
 
     return Info();
+
+    CO_SIM_IO_CATCH
 }
 
 
 void SocketCommunication::PrepareConnection(const Info& I_Info)
 {
+    CO_SIM_IO_TRY
+
+    // CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>0) << "Using IP Address: " << GetIpAddress(true) << std::endl;
+
     // preparing the acceptors to get the ports used for connecting the sockets
     if (GetIsPrimaryConnection()) {
         using namespace asio::ip;
-        tcp::endpoint port_selection_endpoint(asio::ip::make_address(GetIpAddress()), 0); // using port 0 means that it will look for a free port
+        tcp::endpoint port_selection_endpoint(asio::ip::make_address(mIpAddress), 0); // using port 0 means that it will look for a free port
         mpAsioAcceptor = std::make_shared<tcp::acceptor>(mAsioContext, port_selection_endpoint);
         mPortNumber = mpAsioAcceptor->local_endpoint().port();
 
-        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number " << mPortNumber << std::endl;
+        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number: " << mPortNumber << std::endl;
 
         // collect all port numbers on rank 0
         // to exchange them during the handshake
@@ -154,15 +218,25 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
         my_ports[0] = mPortNumber;
         r_data_comm.Gather(my_ports, mAllPortNumbers, 0);
     }
+
+    CO_SIM_IO_CATCH
 }
 
 void SocketCommunication::DerivedHandShake() const
 {
+    CO_SIM_IO_TRY
+
+    CO_SIM_IO_ERROR_IF(GetMyInfo().Get<Info>("communication_settings").Get<std::string>("ip_address") != GetPartnerInfo().Get<Info>("communication_settings").Get<std::string>("ip_address")) << "IP addresses don't match!" << std::endl;
+
+    CO_SIM_IO_CATCH
 }
 
 Info SocketCommunication::GetCommunicationSettings() const
 {
+    CO_SIM_IO_TRY
+
     Info info;
+    info.Set("ip_address", mIpAddress);
 
     if (GetIsPrimaryConnection() && GetDataCommunicator().Rank() == 0) {
         std::stringstream port_numbers_stream;
@@ -171,10 +245,14 @@ Info SocketCommunication::GetCommunicationSettings() const
     }
 
     return info;
+
+    CO_SIM_IO_CATCH
 }
 
 void SocketCommunication::GetPortNumber()
 {
+    CO_SIM_IO_TRY
+
     CO_SIM_IO_ERROR_IF(GetIsPrimaryConnection()) << "This function can only be used as secondary connection!" << std::endl;
 
     const auto partner_info = GetPartnerInfo();
@@ -186,37 +264,50 @@ void SocketCommunication::GetPortNumber()
 
     mPortNumber = static_cast<unsigned short>(std::stoul(ports[GetDataCommunicator().Rank()]));
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number " << mPortNumber << std::endl;
+    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number: " << mPortNumber << std::endl;
+
+    CO_SIM_IO_CATCH
 }
 
 void SocketCommunication::Write(const std::string& rData)
 {
+    CO_SIM_IO_TRY
+
     SendSize(rData.size());
     asio::write(*mpAsioSocket, asio::buffer(rData.data(), rData.size()));
+
+    CO_SIM_IO_CATCH
 }
 
 void SocketCommunication::Read(std::string& rData)
 {
+    CO_SIM_IO_TRY
+
     std::size_t received_size = ReceiveSize();
     rData.resize(received_size);
     asio::read(*mpAsioSocket, asio::buffer(&(rData.front()), received_size));
+
+    CO_SIM_IO_CATCH
 }
 
 void SocketCommunication::SendSize(const std::uint64_t Size)
 {
+    CO_SIM_IO_TRY
+
     asio::write(*mpAsioSocket, asio::buffer(&Size, sizeof(Size)));
+
+    CO_SIM_IO_CATCH
 }
 
 std::uint64_t SocketCommunication::ReceiveSize()
 {
+    CO_SIM_IO_TRY
+
     std::uint64_t imp_size_u;
     asio::read(*mpAsioSocket, asio::buffer(&imp_size_u, sizeof(imp_size_u)));
     return imp_size_u;
-}
 
-std::string SocketCommunication::GetIpAddress() const
-{
-    return "127.0.0.1";
+    CO_SIM_IO_CATCH
 }
 
 } // namespace Internals

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -8,8 +8,8 @@
 <!-- code_chunk_output -->
 
 - [File-based communication](#file-based-communication)
-- [Pipe-based communication](#pipe-based-communication)
 - [Socket-based communication](#socket-based-communication)
+- [Pipe-based communication](#pipe-based-communication)
 
 <!-- /code_chunk_output -->
 ---
@@ -73,7 +73,26 @@ Set `communication_format` to `file`.
 |---|---|---|---|---|
 |currently_nothing|
 
+## Socket-based communication
+The data is communicated through network sockets by using the TCP communication protocol (using IPv4). No data is written to the filesystem, this makes it more efficient than the file-based communication.
+**Important**: By default the loopback interface / localhost is used, which cannot communicate across compute nodes. Hence for using this form of communication on a cluster or other system with multiple compute nodes, it is required to specify which network should be used (e.g. infiniband), see below how to specify the input. Otherwise it will hang! On most linux systems the `ifconfig` command can be used to check the available networks. Otherwise contact your system administrator.
+
+The [ASIO](https://think-async.com/Asio/) library is used as a high level interface for the sockets.
+
+The implementation of the _SocketCommunication_ can be found [here](https://github.com/KratosMultiphysics/CoSimIO/blob/master/co_sim_io/includes/communication/socket_communication.hpp).
+
+**Specific Input:**
+
+Set `communication_format` to `socket`.
+
+| name | type | required | default| description |
+|---|---|---|---|---|
+| ip_address | string | - | "127.0.0.1" | specify the ip address used to establish the connection |
+| network_name | string | - | - | the name of the network can be specified _alternatively_ to specifying the ip address. This is used to determine the ip address. Will print the available networks if a wrong name is specified. |
+
 ## Pipe-based communication
+**This form of communication is experimental**
+
 A pipe is a data channel to perform interprocess communication between two processes. No data is written to the filesystem, it is directly exchanged through the memory. This makes it more efficient than the file-based communication.
 
 This form of communication is currently only available under Unix, the Windows implementation is work in progress.
@@ -83,21 +102,6 @@ The implementation of the _PipeCommunication_ can be found [here](https://github
 **Specific Input:**
 
 Set `communication_format` to `pipe`.
-
-| name | type | required | default| description |
-|---|---|---|---|---|
-|currently_nothing|
-
-## Socket-based communication
-The data is communicated through network sockets by using the TCP communication protocol. No data is written to the filesystem, this makes it more efficient than the file-based communication.
-
-The [ASIO](https://think-async.com/Asio/) library is used as a high level interface for the sockets.
-
-The implementation of the _SocketCommunication_ can be found [here](https://github.com/KratosMultiphysics/CoSimIO/blob/master/co_sim_io/includes/communication/socket_communication.hpp).
-
-**Specific Input:**
-
-Set `communication_format` to `socket`.
 
 | name | type | required | default| description |
 |---|---|---|---|---|


### PR DESCRIPTION
Improvements:
- Now it is possible to input the IP-address that should be used
- Alternatively the name of the network can be used to determine the IP address (only available on linux) => mostly useful for Clusters to select e.g. the infiniband network
- Communication of vector data is now done without serialization which in my prelim tests was ~10 times faster