### PR TITLE
[SocketComm] bugfix for distributed memory

### DIFF
--- a/co_sim_io/includes/communication/socket_communication.hpp
+++ b/co_sim_io/includes/communication/socket_communication.hpp
@@ -36,18 +36,16 @@ public:
 private:
     std::shared_ptr<asio::ip::tcp::acceptor> mpAsioAcceptor; // probably sufficient to have local in function
     unsigned short mPortNumber=0;
-    std::vector<int> mAllPortNumbers;
     std::string mIpAddress;
+    std::string mSerializedConnectionInfo;
 
     std::string GetCommunicationName() const override {return "socket";}
 
     void PrepareConnection(const Info& I_Info) override;
 
-    void DerivedHandShake() const override;
-
     Info GetCommunicationSettings() const override;
 
-    void GetPortNumber();
+    void GetConnectionInformation();
 };
 
 } // namespace Internals

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -26,25 +26,6 @@ namespace Internals {
 
 namespace {
 
-std::vector<std::string> SplitStringByDelimiter(
-const std::string& rString,
-const char Delimiter)
-{
-    CO_SIM_IO_TRY
-
-    std::istringstream ss(rString);
-    std::string token;
-
-    std::vector<std::string> splitted_string;
-    while(std::getline(ss, token, Delimiter)) {
-        splitted_string.push_back(token);
-    }
-
-    return splitted_string;
-
-    CO_SIM_IO_CATCH
-}
-
 std::unordered_map<std::string, std::string> GetIpv4Addresses()
 {
     CO_SIM_IO_TRY

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -104,6 +104,26 @@ std::string GetIpAddress(const Info& I_Settings)
     CO_SIM_IO_CATCH
 }
 
+struct ConnectionInfo
+{
+    int PortNumber;
+    std::string IpAddress;
+
+    friend class CoSimIO::Internals::Serializer;
+
+    void save(CoSimIO::Internals::Serializer& rSerializer) const
+    {
+        rSerializer.save("PortNumber", PortNumber);
+        rSerializer.save("IpAddress", IpAddress);
+    }
+
+    void load(CoSimIO::Internals::Serializer& rSerializer)
+    {
+        rSerializer.load("PortNumber", PortNumber);
+        rSerializer.load("IpAddress", IpAddress);
+    }
+};
+
 } // helpers namespace
 
 SocketCommunication::SocketCommunication(
@@ -113,7 +133,9 @@ SocketCommunication::SocketCommunication(
 {
     CO_SIM_IO_TRY
 
-    mIpAddress = GetIpAddress(I_Settings);
+    if (GetIsPrimaryConnection()) {
+        mIpAddress = GetIpAddress(I_Settings);
+    }
 
     CO_SIM_IO_CATCH
 }
@@ -122,7 +144,9 @@ Info SocketCommunication::ConnectDetail(const Info& I_Info)
 {
     CO_SIM_IO_TRY
 
-    if (!GetIsPrimaryConnection()) {GetPortNumber();}
+    if (!GetIsPrimaryConnection()) {GetConnectionInformation();}
+
+    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>0) << "Using IP-Address: " << mIpAddress << " and port number: " << mPortNumber << std::endl;
 
     using namespace asio::ip;
 
@@ -144,8 +168,6 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
 {
     CO_SIM_IO_TRY
 
-    // CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>0) << "Using IP Address: " << GetIpAddress(true) << std::endl;
-
     // preparing the acceptors to get the ports used for connecting the sockets
     if (GetIsPrimaryConnection()) {
         using namespace asio::ip;
@@ -154,26 +176,28 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
         mPortNumber = mpAsioAcceptor->local_endpoint().port();
         // should mpAsioAcceptor be closed?
 
-        CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number: " << mPortNumber << std::endl;
+        // collect all IP-addresses and port numbers on rank 0 to
+        // exchange them during the handshake (which happens only on rank 0)
 
-        // collect all port numbers on rank 0
-        // to exchange them during the handshake
-        // (which happens only on rank 0)
         const auto& r_data_comm = GetDataCommunicator();
-        mAllPortNumbers.resize(r_data_comm.Size());
-        std::vector<int> my_ports(1);
-        my_ports[0] = mPortNumber;
-        r_data_comm.Gather(my_ports, mAllPortNumbers, 0);
+        std::vector<ConnectionInfo> conn_infos;
+
+        ConnectionInfo my_conn_info {mPortNumber, mIpAddress};
+
+        if (r_data_comm.Rank() == 0) {
+            conn_infos.resize(r_data_comm.Size());
+            conn_infos[0] = {mPortNumber, mIpAddress};
+            for (int i=1; i<r_data_comm.Size(); ++i) {
+                r_data_comm.Recv(conn_infos[i], i);
+            }
+        } else {
+            r_data_comm.Send(my_conn_info, 0);
+        }
+
+        StreamSerializer serializer(Serializer::TraceType::SERIALIZER_ASCII); // deliberately using ascii as the info will be saved as string
+        serializer.save("conn_info", conn_infos); // tag is not used here
+        mSerializedConnectionInfo = serializer.GetStringRepresentation();
     }
-
-    CO_SIM_IO_CATCH
-}
-
-void SocketCommunication::DerivedHandShake() const
-{
-    CO_SIM_IO_TRY
-
-    CO_SIM_IO_ERROR_IF(GetMyInfo().Get<Info>("communication_settings").Get<std::string>("ip_address") != GetPartnerInfo().Get<Info>("communication_settings").Get<std::string>("ip_address")) << "IP addresses don't match!" << std::endl;
 
     CO_SIM_IO_CATCH
 }
@@ -186,9 +210,7 @@ Info SocketCommunication::GetCommunicationSettings() const
     info.Set("ip_address", mIpAddress);
 
     if (GetIsPrimaryConnection() && GetDataCommunicator().Rank() == 0) {
-        std::stringstream port_numbers_stream;
-        std::copy(mAllPortNumbers.begin(), mAllPortNumbers.end(), std::ostream_iterator<int>(port_numbers_stream, "-"));
-        info.Set("port_numbers", port_numbers_stream.str());
+        info.Set("connection_info", mSerializedConnectionInfo);
     }
 
     return info;
@@ -196,22 +218,25 @@ Info SocketCommunication::GetCommunicationSettings() const
     CO_SIM_IO_CATCH
 }
 
-void SocketCommunication::GetPortNumber()
+void SocketCommunication::GetConnectionInformation()
 {
     CO_SIM_IO_TRY
 
     CO_SIM_IO_ERROR_IF(GetIsPrimaryConnection()) << "This function can only be used as secondary connection!" << std::endl;
 
     const auto partner_info = GetPartnerInfo();
-    const std::string ports_string = partner_info.Get<Info>("communication_settings").Get<std::string>("port_numbers");
+    const std::string serialized_info = partner_info.Get<Info>("communication_settings").Get<std::string>("connection_info");
 
-    std::vector<std::string> ports = SplitStringByDelimiter(ports_string, '-');
+    std::vector<ConnectionInfo> conn_infos;
 
-    CO_SIM_IO_ERROR_IF(static_cast<int>(ports.size()) != GetDataCommunicator().Size()) << "Wrong number of ports!" << std::endl;
+    StreamSerializer serializer(serialized_info, Serializer::TraceType::SERIALIZER_ASCII);
+    serializer.load("conn_info", conn_infos);
 
-    mPortNumber = static_cast<unsigned short>(std::stoul(ports[GetDataCommunicator().Rank()]));
+    CO_SIM_IO_ERROR_IF(static_cast<int>(conn_infos.size()) != GetDataCommunicator().Size()) << "Wrong number of connection infos!" << std::endl;
 
-    CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>1) << "Using port number: " << mPortNumber << std::endl;
+    const auto& my_conn_info = conn_infos[GetDataCommunicator().Rank()];
+    mPortNumber = my_conn_info.PortNumber;
+    mIpAddress = my_conn_info.IpAddress;
 
     CO_SIM_IO_CATCH
 }

--- a/co_sim_io/sources/communication/socket_communication.cpp
+++ b/co_sim_io/sources/communication/socket_communication.cpp
@@ -124,6 +124,24 @@ struct ConnectionInfo
     }
 };
 
+// this is required as the serializer cannot handle newlines
+void PrepareStringForAsciiSerialization(std::string& rString)
+{
+    const char disallowed_chars[] = {'<', '>'};
+    for (const auto ch : disallowed_chars) {
+        CO_SIM_IO_ERROR_IF_NOT(rString.find(ch) == std::string::npos) << "String contains a character that is not allowed: \"" << std::string(1,ch) << "\"!" << std::endl;
+    }
+
+    std::replace(rString.begin(), rString.end(), '\n', '<');
+    std::replace(rString.begin(), rString.end(), '"', '>');
+}
+
+void RevertAsciiSerialization(std::string& rString)
+{
+    std::replace(rString.begin(), rString.end(), '<', '\n');
+    std::replace(rString.begin(), rString.end(), '>', '"');
+}
+
 } // helpers namespace
 
 SocketCommunication::SocketCommunication(
@@ -194,9 +212,12 @@ void SocketCommunication::PrepareConnection(const Info& I_Info)
             r_data_comm.Send(my_conn_info, 0);
         }
 
-        StreamSerializer serializer(Serializer::TraceType::SERIALIZER_ASCII); // deliberately using ascii as the info will be saved as string
-        serializer.save("conn_info", conn_infos); // tag is not used here
+        StreamSerializer serializer(GetSerializerTraceType());
+        serializer.save("conn_info", conn_infos);
         mSerializedConnectionInfo = serializer.GetStringRepresentation();
+        if (GetSerializerTraceType() != Serializer::TraceType::SERIALIZER_NO_TRACE) {
+            PrepareStringForAsciiSerialization(mSerializedConnectionInfo);
+        }
     }
 
     CO_SIM_IO_CATCH
@@ -225,11 +246,15 @@ void SocketCommunication::GetConnectionInformation()
     CO_SIM_IO_ERROR_IF(GetIsPrimaryConnection()) << "This function can only be used as secondary connection!" << std::endl;
 
     const auto partner_info = GetPartnerInfo();
-    const std::string serialized_info = partner_info.Get<Info>("communication_settings").Get<std::string>("connection_info");
+    std::string serialized_info = partner_info.Get<Info>("communication_settings").Get<std::string>("connection_info");
+
+    if (GetSerializerTraceType() != Serializer::TraceType::SERIALIZER_NO_TRACE) {
+        RevertAsciiSerialization(serialized_info);
+    }
 
     std::vector<ConnectionInfo> conn_infos;
 
-    StreamSerializer serializer(serialized_info, Serializer::TraceType::SERIALIZER_ASCII);
+    StreamSerializer serializer(serialized_info, GetSerializerTraceType());
     serializer.load("conn_info", conn_infos);
 
     CO_SIM_IO_ERROR_IF(static_cast<int>(conn_infos.size()) != GetDataCommunicator().Size()) << "Wrong number of connection infos!" << std::endl;


### PR DESCRIPTION
Now the primary connection dictates the selection of the IP address that is used.
Reason is than in distributed memory each compute-node has its own ip address, and hence only one of them can be used