### PR TITLE
[FileComm] improve how files are made available

### DIFF
--- a/co_sim_io/includes/communication/communication.hpp
+++ b/co_sim_io/includes/communication/communication.hpp
@@ -178,7 +178,9 @@ protected:
     Info GetMyInfo() const;
     Info GetPartnerInfo() const {return mPartnerInfo;};
 
-    fs::path GetTempFileName(const fs::path& rPath) const;
+    fs::path GetTempFileName(
+        const fs::path& rPath,
+        const bool UseAuxFileForFileAvailability=true) const;
 
     fs::path GetFileName(const fs::path& rPath, const std::string& rExtension) const;
 
@@ -186,13 +188,16 @@ protected:
 
     void WaitForPath(
         const fs::path& rPath,
+        const bool UseAuxFileForFileAvailability=true,
         const int PrintEchoLevel=3) const;
 
     void WaitUntilFileIsRemoved(
         const fs::path& rPath,
         const int PrintEchoLevel=3) const;
 
-    void MakeFileVisible(const fs::path& rPath) const;
+    void MakeFileVisible(
+        const fs::path& rPath,
+        const bool UseAuxFileForFileAvailability=true) const;
 
     void RemovePath(const fs::path& rPath) const;
 
@@ -299,7 +304,6 @@ private:
 
     fs::path mCommFolder;
     bool mCommInFolder = true;
-    bool mUseAuxFileForFileAvailability = false;
     bool mAlwaysUseSerializer = false;
     Serializer::TraceType mSerializerTraceType = Serializer::TraceType::SERIALIZER_NO_TRACE;
 

--- a/co_sim_io/includes/communication/file_communication.hpp
+++ b/co_sim_io/includes/communication/file_communication.hpp
@@ -22,6 +22,12 @@
 namespace CoSimIO {
 namespace Internals {
 
+#ifdef CO_SIM_IO_COMPILED_IN_WINDOWS
+constexpr bool USE_AUX_FILE_FOR_FILE_AVAILABILITY = true;
+#else
+constexpr bool USE_AUX_FILE_FOR_FILE_AVAILABILITY = false;
+#endif
+
 class CO_SIM_IO_API FileCommunication : public Communication
 {
 public:
@@ -32,6 +38,7 @@ public:
     ~FileCommunication() override;
 
 private:
+    bool mUseAuxFileForFileAvailability = USE_AUX_FILE_FOR_FILE_AVAILABILITY;
     const bool mUseFileSerializer = true;
 
     std::string GetCommunicationName() const override {return "file";}

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -359,7 +359,7 @@ void Communication::MakeFileVisible(
 
     if (!UseAuxFileForFileAvailability) {
         std::error_code ec;
-        fs::rename(GetTempFileName(rPath), rPath, ec);
+        fs::rename(GetTempFileName(rPath, UseAuxFileForFileAvailability), rPath, ec);
         CO_SIM_IO_ERROR_IF(ec) << rPath << " could not be made visible!\nError code: " << ec.message() << std::endl;
     } else {
         std::ofstream avail_file;

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -29,7 +29,6 @@ Communication::Communication(
     : mpDataComm(I_DataComm),
       mMyName(I_Settings.Get<std::string>("my_name")),
       mConnectTo(I_Settings.Get<std::string>("connect_to")),
-      mUseAuxFileForFileAvailability(I_Settings.Get<bool>("use_aux_file_for_file_availability", false)),
       mAlwaysUseSerializer(I_Settings.Get<bool>("always_use_serializer", false)),
       mWorkingDirectory(I_Settings.Get<std::string>("working_directory", fs::relative(fs::current_path()).string())),
       mEchoLevel(I_Settings.Get<int>("echo_level", 0)),
@@ -263,11 +262,13 @@ void Communication::PostChecks(const Info& I_Info)
     CO_SIM_IO_ERROR_IF_NOT(I_Info.Has("memory_usage_ipc")) << "\"memory_usage_ipc\" must be specified!" << std::endl;
 }
 
-fs::path Communication::GetTempFileName(const fs::path& rPath) const
+fs::path Communication::GetTempFileName(
+    const fs::path& rPath,
+    const bool UseAuxFileForFileAvailability) const
 {
     CO_SIM_IO_TRY
 
-    if (!mUseAuxFileForFileAvailability) {
+    if (!UseAuxFileForFileAvailability) {
         if (mCommInFolder) {
             return rPath.string().insert(mCommFolder.string().length()+1, ".");
         } else {
@@ -310,12 +311,13 @@ fs::path Communication::GetFileName(const fs::path& rPath, const int Rank, const
 
 void Communication::WaitForPath(
     const fs::path& rPath,
+    const bool UseAuxFileForFileAvailability,
     const int PrintEchoLevel) const
 {
     CO_SIM_IO_TRY
 
     CO_SIM_IO_INFO_IF("CoSimIO", GetEchoLevel()>=PrintEchoLevel) << "Waiting for: " << rPath << std::endl;
-    if (!mUseAuxFileForFileAvailability) {
+    if (!UseAuxFileForFileAvailability) {
         Utilities::WaitUntilPathExists(rPath);
     } else {
         fs::path avail_file = fs::path(rPath.string()+".avail");
@@ -349,11 +351,13 @@ void Communication::WaitUntilFileIsRemoved(
     CO_SIM_IO_CATCH
 }
 
-void Communication::MakeFileVisible(const fs::path& rPath) const
+void Communication::MakeFileVisible(
+    const fs::path& rPath,
+    const bool UseAuxFileForFileAvailability) const
 {
     CO_SIM_IO_TRY
 
-    if (!mUseAuxFileForFileAvailability) {
+    if (!UseAuxFileForFileAvailability) {
         std::error_code ec;
         fs::rename(GetTempFileName(rPath), rPath, ec);
         CO_SIM_IO_ERROR_IF(ec) << rPath << " could not be made visible!\nError code: " << ec.message() << std::endl;
@@ -403,12 +407,12 @@ void Communication::SynchronizeAll(const std::string& rTag) const
             CO_SIM_IO_ERROR_IF_NOT(fs::exists(GetTempFileName(file_name_primary))) << "Primary sync file " << file_name_primary << " could not be created!" << std::endl;
             MakeFileVisible(file_name_primary);
 
-            WaitForPath(file_name_secondary, 2);
+            WaitForPath(file_name_secondary, true, 2);
             RemovePath(file_name_secondary);
 
             WaitUntilFileIsRemoved(file_name_primary, 2);
         } else {
-            WaitForPath(file_name_primary, 2);
+            WaitForPath(file_name_primary, true, 2);
             RemovePath(file_name_primary);
 
             std::ofstream sync_file;
@@ -472,7 +476,7 @@ void Communication::HandShake(const Info& I_Info)
             MakeFileVisible(rMyFileName);
 
             // now get the info from the other
-            WaitForPath(rOtherFileName, 1);
+            WaitForPath(rOtherFileName, true, 1);
 
             { // necessary as FileSerializer releases resources on destruction!
                 FileSerializer serializer_load(rOtherFileName.string(), mSerializerTraceType);

--- a/co_sim_io/sources/communication/file_communication.cpp
+++ b/co_sim_io/sources/communication/file_communication.cpp
@@ -82,6 +82,10 @@ void FileCommunication::DerivedHandShake() const
 {
     CO_SIM_IO_TRY
 
+    const bool my_use_aux_file_for_file_availability = GetMyInfo().Get<Info>("communication_settings").Get<bool>("use_aux_file_for_file_availability");
+    const bool partner_use_aux_file_for_file_availability = GetPartnerInfo().Get<Info>("communication_settings").Get<bool>("use_aux_file_for_file_availability");
+    CO_SIM_IO_ERROR_IF(my_use_aux_file_for_file_availability != partner_use_aux_file_for_file_availability) << std::boolalpha << "Mismatch in use_aux_file_for_file_availability!\nMy use_aux_file_for_file_availability: " << my_use_aux_file_for_file_availability << "\nPartner use_aux_file_for_file_availability: " << partner_use_aux_file_for_file_availability << std::noboolalpha << "\nNote that the default on unix is false, while the default on windows is true!"<< std::endl;
+
     const bool my_use_file_serializer = GetMyInfo().Get<Info>("communication_settings").Get<bool>("use_file_serializer");
     const bool partner_use_file_serializer = GetPartnerInfo().Get<Info>("communication_settings").Get<bool>("use_file_serializer");
     CO_SIM_IO_ERROR_IF(my_use_file_serializer != partner_use_file_serializer) << std::boolalpha << "Mismatch in use_file_serializer!\nMy use_file_serializer: " << my_use_file_serializer << "\nPartner use_file_serializer: " << partner_use_file_serializer << std::noboolalpha << std::endl;
@@ -94,6 +98,7 @@ Info FileCommunication::GetCommunicationSettings() const
     CO_SIM_IO_TRY
 
     Info info;
+    info.Set("use_aux_file_for_file_availability", mUseAuxFileForFileAvailability);
     info.Set("use_file_serializer", mUseFileSerializer);
 
     return info;

--- a/co_sim_io/sources/communication/file_communication.cpp
+++ b/co_sim_io/sources/communication/file_communication.cpp
@@ -63,6 +63,9 @@ FileCommunication::FileCommunication(
       mUseAuxFileForFileAvailability(I_Settings.Get<bool>("use_aux_file_for_file_availability", USE_AUX_FILE_FOR_FILE_AVAILABILITY)),
       mUseFileSerializer(I_Settings.Get<bool>("use_file_serializer", true))
 {
+#ifdef CO_SIM_IO_COMPILED_IN_WINDOWS
+    CO_SIM_IO_INFO_IF("CoSimIO", !mUseAuxFileForFileAvailability) << "WARNING: Using rename for making files available can cause race conditions as it is not atomic in Windows! Use \"use_aux_file_for_file_availability\" = false to avoid this" << std::endl;
+#endif
 }
 
 FileCommunication::~FileCommunication()

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -48,7 +48,7 @@ The following settings are available for all methods of communication:
 | working_directory     | string | - | current working directory | path to the working directory |
 | use_folder_for_communication | bool | - | true  | whether the files used for communication are written in a dedicated folder. Deadlocks from leftover files from previous executions are less likely to happen as they can be cleanup up. |
 | always_use_serializer | bool | - | false  | use the Serializer also when it is not necessary, e.g. for basic types such as Im-/ExportData. This is ~ 10x slower but more stable, especially when combined with ascii-serialization |
-| serializer_trace_type | string | - | no_trace | mode for the `Serializer`: `no_trace` (fastest method, binary format, without any debugging checks), `trace_error` (ascii format, limited error checking), `trace_all` (slow, ascii format, detailed error checking, should only be used for debugging) |
+| serializer_trace_type | string | - | no_trace | mode for the `Serializer`: `no_trace` (fastest method, binary format, without any debugging checks), `ascii` (ascii format, without any debugging checks), `trace_error` (ascii format, checks are enabled), `trace_all` (ascii format, checks are enabled and printed, hence very verbose!) |
 | echo_level            | int    | - | 0 | decides how much output is printed |
 | print_timing          | bool   | - | false | whether timing information should be printed |
 

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -47,7 +47,6 @@ The following settings are available for all methods of communication:
 | is_primary_connection | bool   | - | determined from other input | whether this is the primary connection, if not specified it is determined automatically from the names of the partners |
 | working_directory     | string | - | current working directory | path to the working directory |
 | use_folder_for_communication | bool | - | true  | whether the files used for communication are written in a dedicated folder. Deadlocks from leftover files from previous executions are less likely to happen as they can be cleanup up. |
-| use_aux_file_for_file_availability | bool | - | false  | select whether files are made available by use of an auxiliary file or via rename. |
 | always_use_serializer | bool | - | false  | use the Serializer also when it is not necessary, e.g. for basic types such as Im-/ExportData. This is ~ 10x slower but more stable, especially when combined with ascii-serialization |
 | serializer_trace_type | string | - | no_trace | mode for the `Serializer`: `no_trace` (fastest method, binary format, without any debugging checks), `trace_error` (ascii format, limited error checking), `trace_all` (slow, ascii format, detailed error checking, should only be used for debugging) |
 | echo_level            | int    | - | 0 | decides how much output is printed |
@@ -65,6 +64,9 @@ The following settings are available for all methods of communication:
 
 ## File-based communication
 As the name indicates, this method uses files for communicating data. It is robust and useful for debugging. It is the preferred method for implementing the _CoSimIO_ in a new code, as it is intuitive to follow the flow of data through the files.
+In order to prevent race conditions when accessing the files, two mechanisms are available (which can be selected with `use_aux_file_for_file_availability`):
+- `use_aux_file_for_file_availability == true`: An empty auxiliary file is created once the real file with the data is ready to be read. This is used unconditionally for any synchronization files.
+- `use_aux_file_for_file_availability == false`: On Unix operating systems, renaming of files is atomic. Hence the data is written to a file with a temporary name. Once the writing is complete, the file is renamed to the real name for the other partner to read from it. This is especially useful for clusters since it avoids writing of auxiliar files on slow filesystems.
 
 The implementation of the _FileCommunication_ can be found [here](https://github.com/KratosMultiphysics/CoSimIO/blob/master/co_sim_io/includes/communication/file_communication.hpp).
 
@@ -74,6 +76,7 @@ Set `communication_format` to `file`.
 
 | name | type | required | default| description |
 |---|---|---|---|---|
+| use_aux_file_for_file_availability | bool | - | Windows: true; Unix: false  | select whether files are made available by use of an auxiliary file or via rename. |
 | use_file_serializer | bool   | - | true | Using the `FileSerializer` (which directly uses a file stream to read/write data) over the `StreamSerializer` (which first to reads/writes to a stringstream before writing everything to the file at once) |
 
 ## Socket-based communication

--- a/docs/communication.md
+++ b/docs/communication.md
@@ -66,7 +66,7 @@ The following settings are available for all methods of communication:
 As the name indicates, this method uses files for communicating data. It is robust and useful for debugging. It is the preferred method for implementing the _CoSimIO_ in a new code, as it is intuitive to follow the flow of data through the files.
 In order to prevent race conditions when accessing the files, two mechanisms are available (which can be selected with `use_aux_file_for_file_availability`):
 - `use_aux_file_for_file_availability == true`: An empty auxiliary file is created once the real file with the data is ready to be read. This is used unconditionally for any synchronization files.
-- `use_aux_file_for_file_availability == false`: On Unix operating systems, renaming of files is atomic. Hence the data is written to a file with a temporary name. Once the writing is complete, the file is renamed to the real name for the other partner to read from it. This is especially useful for clusters since it avoids writing of auxiliar files on slow filesystems.
+- `use_aux_file_for_file_availability == false`: On Unix operating systems, renaming of files is atomic (on Windows it is not which can cause race conditions!). Hence the data is written to a file with a temporary name. Once the writing is complete, the file is renamed to the real name for the other partner to read from it. This is especially useful for clusters since it avoids writing of auxiliar files on slow filesystems.
 
 The implementation of the _FileCommunication_ can be found [here](https://github.com/KratosMultiphysics/CoSimIO/blob/master/co_sim_io/includes/communication/file_communication.hpp).
 

--- a/tests/co_sim_io/cpp/test_communication.cpp
+++ b/tests/co_sim_io/cpp/test_communication.cpp
@@ -617,6 +617,7 @@ TEST_CASE("FileCommunication_serializer_data" * doctest::timeout(250))
 
 TEST_CASE("FileCommunication_avail_file" * doctest::timeout(250))
 {
+    // could be skipped as in Win by default the aux file is used
     CoSimIO::Info settings;
     settings.Set<std::string>("communication_format", "file");
     settings.Set<bool>("use_aux_file_for_file_availability", true);


### PR DESCRIPTION
on windows, renaming files is not atomic and can cause race conditions, hence using aux fles for the synchronization there.
On unix the default is to rename files, which is especialy good for the cluster as then least amount of files is used