### PR TITLE
Set file permissions correctly

### DIFF
--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -25,11 +25,15 @@ namespace Internals {
 
 void AddFilePermissions(const fs::path& rPath)
 {
+    CO_SIM_IO_TRY
+
     fs::permissions(rPath,
         fs::perms::owner_read  | fs::perms::owner_write |
         fs::perms::group_read  | fs::perms::group_write |
         fs::perms::others_read | fs::perms::others_write,
         fs::perm_options::add);
+
+    CO_SIM_IO_CATCH
 }
 
 Communication::Communication(
@@ -366,17 +370,17 @@ void Communication::MakeFileVisible(
     CO_SIM_IO_TRY
 
     if (!UseAuxFileForFileAvailability) {
+        const fs::path tmp_file_name = GetTempFileName(rPath, UseAuxFileForFileAvailability);
+        AddFilePermissions(tmp_file_name);
         std::error_code ec;
-        fs::rename(GetTempFileName(rPath, UseAuxFileForFileAvailability), rPath, ec);
+        fs::rename(tmp_file_name, rPath, ec);
         CO_SIM_IO_ERROR_IF(ec) << rPath << " could not be made visible!\nError code: " << ec.message() << std::endl;
     } else {
+        AddFilePermissions(rPath);
         std::ofstream avail_file;
         avail_file.open(rPath.string() + ".avail");
         avail_file.close();
-        AddFilePermissions(rPath.string() + ".avail");
     }
-
-    AddFilePermissions(rPath);
 
     CO_SIM_IO_CATCH
 }

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -26,7 +26,9 @@ namespace Internals {
 void AddFilePermissions(const fs::path& rPath)
 {
     fs::permissions(rPath,
-        fs::perms::owner_all | fs::perms::group_all | fs::perms::others_all,
+        fs::perms::owner_read  | fs::perms::owner_write |
+        fs::perms::group_read  | fs::perms::group_write |
+        fs::perms::others_read | fs::perms::others_write,
         fs::perm_options::add);
 }
 

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -23,6 +23,13 @@
 namespace CoSimIO {
 namespace Internals {
 
+void AddFilePermissions(const fs::path& rPath)
+{
+    fs::permissions(rPath,
+        fs::perms::owner_all | fs::perms::group_all | fs::perms::others_all,
+        fs::perm_options::add);
+}
+
 Communication::Communication(
     const Info& I_Settings,
     std::shared_ptr<DataCommunicator> I_DataComm)
@@ -139,6 +146,7 @@ void Communication::BaseConnectDetail(const Info& I_Info)
         CO_SIM_IO_INFO_IF("CoSimIO", ec) << "Warning, communication directory (" << mCommFolder << ") could not be deleted!\nError code: " << ec.message() << std::endl;
         if (!fs::exists(mCommFolder)) {
             fs::create_directory(mCommFolder);
+            AddFilePermissions(mCommFolder); // otherwise the process with lower rights cannot delete files in it
         }
     }
 
@@ -363,7 +371,10 @@ void Communication::MakeFileVisible(
         std::ofstream avail_file;
         avail_file.open(rPath.string() + ".avail");
         avail_file.close();
+        AddFilePermissions(rPath.string() + ".avail");
     }
+
+    AddFilePermissions(rPath);
 
     CO_SIM_IO_CATCH
 }


### PR DESCRIPTION
This should allow that one side uses elevated (i.e. sudo or admin) privileges while the other one does not. I solve this by giving each file that is created equal permissions.

With the proposed solution it works for me on linux, but I cannot reproduce the problem in my Windows setup (regular Win10 with VS2019)