### PR TITLE
Fixed variable name in Element use

### DIFF
--- a/docs/model_part/model_part_cpp.md
+++ b/docs/model_part/model_part_cpp.md
@@ -121,7 +121,7 @@ for (auto node_it=model_part.NodesBegin(); node_it!=model_part.NodesEnd(); ++nod
 }
 
 // iterate elements (with range based loop)
-for (auto& elem : model_part.Elements()) {
+for (auto& element : model_part.Elements()) {
     // do sth with element, e.g. print the id:
     std::cout << element.Id() << std::endl;
 }


### PR DESCRIPTION
Fixed minor typo in the variable names from the documentation on how to use the Element class from ModelPart.