### PR TITLE
Fix pipe defines old kernels

### DIFF
--- a/co_sim_io/includes/communication/local_socket_communication.hpp
+++ b/co_sim_io/includes/communication/local_socket_communication.hpp
@@ -14,7 +14,6 @@
 #define CO_SIM_IO_LOCAL_SOCKET_COMMUNICATION_INCLUDED
 
 // System includes
-#include <thread>
 
 // Project includes
 #include "includes/communication/base_socket_communication.hpp"

--- a/co_sim_io/includes/communication/socket_communication.hpp
+++ b/co_sim_io/includes/communication/socket_communication.hpp
@@ -14,7 +14,6 @@
 #define CO_SIM_IO_SOCKET_COMMUNICATION_INCLUDED
 
 // System includes
-#include <thread>
 
 // Project includes
 #include "includes/communication/base_socket_communication.hpp"

--- a/co_sim_io/sources/communication/communication.cpp
+++ b/co_sim_io/sources/communication/communication.cpp
@@ -524,7 +524,7 @@ void Communication::HandShake(const Info& I_Info)
 
         auto print_endianness = [](const bool IsBigEndian){return IsBigEndian ? "big endian" : "small endian";};
 
-        CO_SIM_IO_INFO_IF("CoSimIO", Utilities::IsBigEndian() != mPartnerInfo.Get<bool>("is_big_endian")) << "WARNING: Parnters have different endianness, check results carefully! It is recommended to use serialized ascii commuication.\n    My endianness:      " << print_endianness(Utilities::IsBigEndian()) << "\n    Partner endianness: " << print_endianness(mPartnerInfo.Get<bool>("is_big_endian")) << std::endl;
+        CO_SIM_IO_INFO_IF("CoSimIO", Utilities::IsBigEndian() != mPartnerInfo.Get<bool>("is_big_endian")) << "WARNING: Parnters have different endianness, check results carefully! It is recommended to use serialized ascii communication.\n    My endianness:      " << print_endianness(Utilities::IsBigEndian()) << "\n    Partner endianness: " << print_endianness(mPartnerInfo.Get<bool>("is_big_endian")) << std::endl;
 
         // more things can be done in derived class if necessary
         DerivedHandShake();

--- a/co_sim_io/sources/communication/pipe_communication.cpp
+++ b/co_sim_io/sources/communication/pipe_communication.cpp
@@ -140,7 +140,9 @@ PipeCommunication::BidirectionalPipe::BidirectionalPipe(
         CO_SIM_IO_ERROR_IF((mPipeHandleWrite = open(mPipeNameWrite.c_str(), O_WRONLY)) < 0) << "Pipe " << mPipeNameWrite << " could not be opened!" << std::endl;
     }
 
-    #ifdef CO_SIM_IO_COMPILED_IN_LINUX
+    // if possible try to resize the pipes to the buffer size
+    // not resizing still works but leads to communication in more chunks
+    #if defined(F_GETPIPE_SZ) && defined(F_SETPIPE_SZ) // some old kernels don't define this
     const int pipe_buffer_size_read = fcntl(mPipeHandleRead, F_GETPIPE_SZ);
     const int pipe_buffer_size_write = fcntl(mPipeHandleWrite, F_GETPIPE_SZ);
 


### PR DESCRIPTION
some old kernels don't define those, hence checking before using them