### PR TITLE
MacOS RPath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,8 +124,7 @@ message("CMAKE_CXX_FLAGS:" ${CMAKE_CXX_FLAGS})
 message("CMAKE_C_FLAGS:" ${CMAKE_C_FLAGS})
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-    # to suppress warning "MACOSX_RPATH is not specified for the following targets"
-    set(CMAKE_MACOSX_RPATH 0)
+    cmake_policy(SET CMP0042 NEW)
 endif()
 
 # clean the bin directory


### PR DESCRIPTION
## Description

Allow `CMake` to set `RPath` in built binaries when installing on MacOS. This fixes an issue when compiling `CoSimIO` from `KratosMultiphysics`, where loading `CoSimIO` failed due expired library paths after installing. 

*P.S.: I don't have much experience on MacOS, so please go easy on me.*