### PR TITLE
[Sources] Fix code location in some Windows systems

### DIFF
--- a/co_sim_io/sources/code_location.cpp
+++ b/co_sim_io/sources/code_location.cpp
@@ -32,7 +32,7 @@ std::string CodeLocation::GetCleanFileName() const
     const std::string to_string = "/";
     while ((start_position = clean_file_name.find(from_string, start_position)) != std::string::npos) {
         clean_file_name.replace(start_position, from_string.length(), to_string);
-        start_position += to_string.length(); // ...
+        start_position += to_string.length();
     }
 
     // Remove the path up to the co_sim_io root folder

--- a/co_sim_io/sources/code_location.cpp
+++ b/co_sim_io/sources/code_location.cpp
@@ -15,7 +15,7 @@
 // Project includes
 #include "includes/code_location.hpp"
 #ifndef _WIN32
-    #include "includes/filesystem_inc.hpp"
+#include "includes/filesystem_inc.hpp"
 #endif
 
 namespace CoSimIO {

--- a/co_sim_io/sources/code_location.cpp
+++ b/co_sim_io/sources/code_location.cpp
@@ -14,15 +14,18 @@
 
 // Project includes
 #include "includes/code_location.hpp"
-// #include "includes/filesystem_inc.hpp"
+#ifndef _WIN32
+    #include "includes/filesystem_inc.hpp"
+#endif
 
 namespace CoSimIO {
 namespace Internals {
 
 std::string CodeLocation::GetCleanFileName() const
 {
-    // return fs::canonical(fs::path(GetFileName())).lexically_relative(fs::absolute(".")).string();
-
+#ifndef _WIN32
+    return fs::canonical(fs::path(GetFileName())).lexically_relative(fs::absolute(".")).string();
+#else
     // NOTE: This is a workaround for the above, since it doesn't work on some Windows systems. Inspired in Kratos solution https://github.com/KratosMultiphysics/Kratos/blob/c1d9b2e30b557612aa379acfa2e16298523731a8/kratos/sources/code_location.cpp#L46
     std::string clean_file_name(GetFileName());
 
@@ -46,6 +49,7 @@ std::string CodeLocation::GetCleanFileName() const
 
     // Return the file name
     return clean_file_name;
+#endif
 }
 
 } // namespace Internals

--- a/co_sim_io/sources/code_location.cpp
+++ b/co_sim_io/sources/code_location.cpp
@@ -14,15 +14,39 @@
 
 // Project includes
 #include "includes/code_location.hpp"
-#include "includes/filesystem_inc.hpp"
+// #include "includes/filesystem_inc.hpp"
 
 namespace CoSimIO {
 namespace Internals {
 
 std::string CodeLocation::GetCleanFileName() const
 {
-    return fs::canonical(fs::path(GetFileName())).lexically_relative(fs::absolute(".")).string();
+    // return fs::canonical(fs::path(GetFileName())).lexically_relative(fs::absolute(".")).string();
+
+    // NOTE: This is a workaround for the above, since it doesn't work on some Windows systems. Inspired in Kratos solution https://github.com/KratosMultiphysics/Kratos/blob/c1d9b2e30b557612aa379acfa2e16298523731a8/kratos/sources/code_location.cpp#L46
+    std::string clean_file_name(GetFileName());
+
+    // Replace all backslashes with forward slashes
+    std::size_t start_position = 0;
+    const std::string from_string = "\\";
+    const std::string to_string = "/";
+    while ((start_position = clean_file_name.find(from_string, start_position)) != std::string::npos) {
+        clean_file_name.replace(start_position, from_string.length(), to_string);
+        start_position += to_string.length(); // ...
+    }
+
+    // Remove the path up to the co_sim_io root folder
+    std::size_t co_sim_io_root_position = clean_file_name.rfind("/co_sim_io/");
+    if (co_sim_io_root_position != std::string::npos) {
+        clean_file_name.erase(0, co_sim_io_root_position+1);
+        return clean_file_name;
+    }
+    if (co_sim_io_root_position != std::string::npos)
+        clean_file_name.erase(0, co_sim_io_root_position + 1 );
+
+    // Return the file name
+    return clean_file_name;
 }
 
-} // namespace Interals
+} // namespace Internals
 } // namespace CoSimIO


### PR DESCRIPTION
Fixes https://github.com/KratosMultiphysics/CoSimIO/issues/350

This PR focuses on improving the handling of file paths in the `CodeLocation` class within the `co_sim_io` project. The changes include modifications to the `GetCleanFileName` function. It addresses an issue where the previous implementation didn't work correctly on certain Windows systems (in my machine it worked, but @pooyan-dadvand found a bug in https://github.com/KratosMultiphysics/CoSimIO/issues/350). The commit introduces a workaround inspired by a similar solution in the Kratos project. Specifically, the commit replaces backslashes with forward slashes in file paths and removes the path up to the `co_sim_io` root folder, ensuring consistent and accurate results across different systems.

Changes Made:
- Modified the `GetCleanFileName` function in the `CodeLocation` class.
- Introduced a workaround to replace backslashes with forward slashes in file paths.
- Removed the path up to the `co_sim_io` root folder to provide cleaner file names.