### PR TITLE
[Scripts] Adding Windows scripts

### DIFF
--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -18,9 +18,6 @@ if not defined CO_SIM_IO_BUILD_PYTHON set CO_SIM_IO_BUILD_PYTHON=OFF
 if not defined CO_SIM_IO_BUILD_FORTRAN set CO_SIM_IO_BUILD_FORTRAN=OFF
 if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
 
-rem Warning: In windows this option only works if you run through a terminal with admin privileges
-rem set COSIMIO_INSTALL_PYTHON_USING_LINKS=ON
-
 rem Set basic configuration
 if not defined COSIMIO_BUILD_TYPE set COSIMIO_BUILD_TYPE=Release
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -12,10 +12,6 @@ if not defined COSIMIO_SOURCE set COSIMIO_SOURCE=%~dp0..
 if not defined COSIMIO_BUILD set COSIMIO_BUILD=%COSIMIO_SOURCE%/build
 
 rem Set defaults
-if not defined CO_SIM_IO_BUILD_TESTING set CO_SIM_IO_BUILD_TESTING=ON
-if not defined CO_SIM_IO_BUILD_C set CO_SIM_IO_BUILD_C=OFF
-if not defined CO_SIM_IO_BUILD_PYTHON set CO_SIM_IO_BUILD_PYTHON=OFF
-if not defined CO_SIM_IO_BUILD_FORTRAN set CO_SIM_IO_BUILD_FORTRAN=OFF
 if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
 
 rem Set basic configuration

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,0 +1,53 @@
+@echo off
+rem Please do not modify this script. Copyt into the build folder
+
+rem Set compiler
+set CC=cl.exe
+set CXX=cl.exe
+
+rem Set variables
+if not defined CMAKE_GENERATOR set CMAKE_GENERATOR=Visual Studio 16 2019
+if not defined NUMBER_OF_COMPILATION_CORES set NUMBER_OF_COMPILATION_CORES=%NUMBER_OF_PROCESSORS%
+if not defined COSIMIO_SOURCE set COSIMIO_SOURCE=%~dp0..
+if not defined COSIMIO_BUILD set COSIMIO_BUILD=%COSIMIO_SOURCE%/build
+
+rem Set defaults
+if not defined CO_SIM_IO_BUILD_TESTING set CO_SIM_IO_BUILD_TESTING=ON
+if not defined CO_SIM_IO_BUILD_C set CO_SIM_IO_BUILD_C=OFF
+if not defined CO_SIM_IO_BUILD_PYTHON set CO_SIM_IO_BUILD_PYTHON=OFF
+if not defined CO_SIM_IO_BUILD_FORTRAN set CO_SIM_IO_BUILD_FORTRAN=OFF
+if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
+
+rem Warning: In windows this option only works if you run through a terminal with admin privileges
+rem set COSIMIO_INSTALL_PYTHON_USING_LINKS=ON
+
+rem Set basic configuration
+if not defined COSIMIO_BUILD_TYPE set COSIMIO_BUILD_TYPE=Release
+
+rem Clean
+del /F /Q "%COSIMIO_BUILD%\%COSIMIO_BUILD_TYPE%\cmake_install.cmake"
+del /F /Q "%COSIMIO_BUILD%\%COSIMIO_BUILD_TYPE%\CMakeCache.txt"
+del /F /Q "%COSIMIO_BUILD%\%COSIMIO_BUILD_TYPE%\CMakeFiles"
+
+rem Configure
+@echo on
+cmake                                                   ^
+-G "%CMAKE_GENERATOR%"                                  ^
+-H"%COSIMIO_SOURCE%"                                    ^
+-B"%COSIMIO_BUILD%\%COSIMIO_BUILD_TYPE%"                ^
+-DCMAKE_BUILD_TYPE=%COSIMIO_BUILD_TYPE%                 ^
+-DCO_SIM_IO_BUILD_MPI=OFF                               ^
+-DCO_SIM_IO_BUILD_TESTING=%CO_SIM_IO_BUILD_TESTING%     ^
+-DCO_SIM_IO_BUILD_C=%CO_SIM_IO_BUILD_C%                 ^
+-DCO_SIM_IO_BUILD_PYTHON=%CO_SIM_IO_BUILD_PYTHON%       ^
+-DCO_SIM_IO_BUILD_FORTRAN=%CO_SIM_IO_BUILD_FORTRAN%     ^
+-DCO_SIM_IO_STRICT_COMPILER=%CO_SIM_IO_STRICT_COMPILER%
+
+rem Build
+IF "%CMAKE_GENERATOR%"=="Ninja" (
+    cmake --build "%COSIMIO_BUILD%/%COSIMIO_BUILD_TYPE%" --target install -- -j%NUMBER_OF_COMPILATION_CORES%
+) ELSE (
+    cmake --build "%COSIMIO_BUILD%/%COSIMIO_BUILD_TYPE%" --target install -- /property:configuration=%COSIMIO_BUILD_TYPE% /p:Platform=x64
+)
+
+goto:eof

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,5 +1,5 @@
 @echo off
-rem Please do not modify this script. Copyt into the build folder
+rem Please do not modify this script. Copy it into the build folder
 
 rem Set compiler
 set CC=cl.exe

--- a/scripts/build_and_test.bat
+++ b/scripts/build_and_test.bat
@@ -1,0 +1,22 @@
+@echo off
+REM should be called with "scripts\build_and_test.bat" from the build directory
+
+REM rmdir /s /q build
+if not defined COSIMIO_BUILD_TYPE set COSIMIO_BUILD_TYPE=Release
+set COSIMIO_SOURCE=%~dp0..
+set CO_SIM_IO_BUILD_TESTING=ON
+set CO_SIM_IO_BUILD_PYTHON=ON
+call %COSIMIO_SOURCE%\scripts\build.bat
+
+echo "Running CTests"
+cd %COSIMIO_SOURCE%\build\%COSIMIO_BUILD_TYPE%
+REM The following command may need to be adjusted depending on the exact behavior of "ctest" on Windows.
+ctest --output-on-failure
+if errorlevel 1 (
+    echo CTests failed, but continuing...
+)
+
+echo "Running Python Tests"
+set PATH=%PATH%;%COSIMIO_SOURCE%\bin
+set PYTHONPATH=%PYTHONPATH%;%COSIMIO_SOURCE%\bin
+py.exe %COSIMIO_SOURCE%\tests\run_python_tests.py

--- a/scripts/build_c.bat
+++ b/scripts/build_c.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Should be copied to the build directory
+
+set COSIMIO_SOURCE=%~dp0..
+set CO_SIM_IO_BUILD_C=ON
+call %COSIMIO_SOURCE%\scripts\build.bat

--- a/scripts/build_cpp.bat
+++ b/scripts/build_cpp.bat
@@ -1,0 +1,5 @@
+@echo off
+REM Should be copied to the build directory
+
+set COSIMIO_SOURCE=%~dp0..
+call %COSIMIO_SOURCE%\scripts\build.bat

--- a/scripts/build_python.bat
+++ b/scripts/build_python.bat
@@ -1,0 +1,6 @@
+@echo off
+REM Should be copied to the build directory
+
+set COSIMIO_SOURCE=%~dp0..
+set CO_SIM_IO_BUILD_PYTHON=ON
+call %COSIMIO_SOURCE%\scripts\build.bat


### PR DESCRIPTION
This PR introduces a set of new build scripts for Windows OS. These scripts are added to the "scripts" directory and serve various purposes. Here's a brief overview of the changes made:

1. `scripts/build.bat`: This script sets up the compiler and various environment variables, then configures and builds the project using CMake. It also includes options to control the build type, enable/disable testing, and build components like C, Python, and Fortran.

2. `scripts/build_and_test.bat`: This script is designed to be run from the build directory. It invokes the `scripts/build.bat` script with specific options and then runs CTests for testing the project. Afterward, it runs Python tests.

3. `scripts/build_c.bat`: This script is used to build the C component of the project by calling the `scripts/build.bat` script with appropriate settings.

4. `scripts/build_cpp.bat`: This script is used to build the C++ component of the project by calling the `scripts/build.bat` script.

5. `scripts/build_python.bat`: This script is used to build the Python component of the project by calling the `scripts/build.bat` script.

In summary, this PR adds new build scripts to the project, making it easier to configure, build, and test different components of the project, such as C, C++, and Python, with various options and settings in the Windows operative system.

Fixes https://github.com/KratosMultiphysics/CoSimIO/issues/359 and https://github.com/KratosMultiphysics/CoSimIO/issues/360