### PR TITLE
[Documentation] Update documentation for CoSimIO integration in C++, C, and Python for Windows

### DIFF
--- a/docs/tutorials/c/integration_co_sim_io.md
+++ b/docs/tutorials/c/integration_co_sim_io.md
@@ -39,11 +39,18 @@ Several options for using/integrating the _CoSimIO_ exist:
         Here the _CoSimIO_ is directly integrated into the host code and added with `add_subdirectory(CoSimIO)`. CMake then takes care of compiling and installing the _CoSimIO_.
         Kratos uses this way to integrate the CoSimIO, check the [`CMakeLists.txt` of the CoSimulationApplication for details](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/CoSimulationApplication/CMakeLists.txt)
     - Compiling _CoSimIO_ outside the host project:
-        One can use [build_c.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.sh) for compiling it.
+        One can use [build_c.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.sh) or [build_c.bat](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.bat) for compiling it.
 
-        ```bash
-        $ bash scripts/build_c.sh
-        ```
+        - For *GNU/Linux* or *MacOS*:
+            ```bash
+            $ bash scripts/build_c.sh
+            ```
+
+        - For Windows OS:
+
+            ```cmd
+            $ scripts/build_c.bat
+            ```
 
     After compiling, the headers need to be included (e.g. with `include_directories`) and the `co_sim_io_c` shared library needs to be linked (e.g with `target_link_libraries`).
     ```
@@ -52,11 +59,18 @@ Several options for using/integrating the _CoSimIO_ exist:
     ```
 
 - Compiling _CoSimIO_ outside the host and manually integrating it:
-    One can use [build_c.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.sh) for compiling it.
+    One can use [build_c.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.sh) or [build_c.bat](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_c.bat) for compiling it.
 
-    ```bash
-    $ bash scripts/build_c.sh
-    ```
+    - For *GNU/Linux* or *MacOS*:
+        ```bash
+        $ bash scripts/build_c.sh
+        ```
+
+    - For Windows OS:
+
+        ```cmd
+        $ scripts/build_c.bat
+        ```
 
     Is important that the compiler can find the header files of the _CoSimIO_. For this, one can add the folder `co_sim_io` to the include path.
     Example:

--- a/docs/tutorials/cpp/integration_co_sim_io.md
+++ b/docs/tutorials/cpp/integration_co_sim_io.md
@@ -39,11 +39,18 @@ Several options for using/integrating the _CoSimIO_ exist:
         Here the _CoSimIO_ is directly integrated into the host code and added with `add_subdirectory(CoSimIO)`. CMake then takes care of compiling and installing the _CoSimIO_.
         Kratos uses this way to integrate the CoSimIO, check the [`CMakeLists.txt` of the CoSimulationApplication for details](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/CoSimulationApplication/CMakeLists.txt)
     - Compiling _CoSimIO_ outside the host project:
-        One can use [build_cpp.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.sh) for compiling it.
+        One can use [build_cpp.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.sh) or [build_cpp.bat](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.bat) for compiling it.
 
-        ```bash
-        $ bash scripts/build_cpp.sh
-        ```
+        - For *GNU/Linux* or *MacOS*:
+            ```bash
+            $ bash scripts/build_cpp.sh
+            ```
+
+        - For Windows OS:
+
+            ```cmd
+            $ scripts/build_cpp.bat
+            ```
 
     After compiling, the headers need to be included (e.g. with `include_directories`) and the `co_sim_io` shared library needs to be linked (e.g with `target_link_libraries`).
     ```
@@ -52,11 +59,18 @@ Several options for using/integrating the _CoSimIO_ exist:
     ```
 
 - Compiling _CoSimIO_ outside the host and manually integrating it:
-    One can use [build_cpp.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.sh) for compiling it.
+    One can use [build_cpp.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.sh) or [build_cpp.bat](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_cpp.bat) for compiling it.
 
-    ```bash
-    $ bash scripts/build_cpp.sh
-    ```
+    - For *GNU/Linux* or *MacOS*:
+        ```bash
+        $ bash scripts/build_cpp.sh
+        ```
+
+    - For Windows OS:
+
+        ```cmd
+        $ scripts/build_cpp.bat
+        ```
 
     Is important that the compiler can find the header files of the _CoSimIO_. For this, one can add the folder `co_sim_io` to the include path.
     Example:

--- a/docs/tutorials/python/integration_co_sim_io.md
+++ b/docs/tutorials/python/integration_co_sim_io.md
@@ -36,12 +36,19 @@ This tutorial helps you to integrate the _CoSimIO_ into a solver/software-tool u
 ## Building the CoSimIO
 The Python interface is located in [co_sim_io/python](https://github.com/KratosMultiphysics/CoSimIO/tree/master/co_sim_io/python) folder of the repository. It uses the [pybind11 library](https://github.com/pybind/pybind11) for exposing the C++ code to Python. It is provided in the [expternal_libraries/pybind11](https://github.com/KratosMultiphysics/CoSimIO/tree/master/external_libraries/pybind11) folder of this repo.
 
-One may use the [build_python.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_python.sh) script from the CoSimIO root folder to create a library of the python interface:
+One may use the [build_python.sh](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_python.sh) or [build_python.bat](https://github.com/KratosMultiphysics/CoSimIO/blob/master/scripts/build_python.bat) script from the _CoSimIO_ root folder to create a library of the python interface:
 
-```
-sh scripts/build_python.sh
-```
-This will compile the binaries and install them into the `bin/` subfolder of _CoSimIO_, together with the CoSimIO Python module. Check [here](../../build_options.md) for the available build options.
+- For *GNU/Linux* or *MacOS*:
+    ```bash
+    $ bash scripts/build_python.sh
+    ```
+
+- For Windows OS:
+
+    ```cmd
+    $ scripts/build_python.bat
+    ```
+This will compile the binaries and install them into the `bin/` subfolder of _CoSimIO_, together with the _CoSimIO_ Python module. Check [here](../../build_options.md) for the available build options.
 
 The created folder structure should look like this:
 ```
@@ -56,7 +63,7 @@ Remember to add the `/bin` folder to your `PYTHONPATH`. For Linux this should lo
 export PYTHONPATH=$PYTHONPATH:/path/to/CoSimIO/bin
 ```
 
-Usually pybind automatically detects the Python installation. Sometimes it can however be necessary to explicitly specify the target Python version. This can be achieved through CMake by setting PYBIND11_PYTHON_VERSION or an exact Python installation can be specified with PYTHON_EXECUTABLE. For example:
+Usually pybind automatically detects the Python installation. Sometimes it can however be necessary to explicitly specify the target Python version. This can be achieved through CMake by setting `PYBIND11_PYTHON_VERSION` or an exact Python installation can be specified with `PYTHON_EXECUTABLE`. For example:
 ```cmake
 -DPYBIND11_PYTHON_VERSION=3.6
 # or


### PR DESCRIPTION
This PR updates the documentation for integrating the *CoSimIO* library into C++, C, and Python projects. It provides detailed instructions for each language on how to compile and integrate *CoSimIO* for Windows. The changes include the addition of build scripts for different platforms and improved clarity in the documentation.

- In the C integration documentation, it separates the instructions for Linux/MacOS and Windows users, providing links to relevant build scripts.
- In the C++ integration documentation, idem.
- In the Python integration documentation, idem.

Overall, these changes make it easier for developers to integrate *CoSimIO*into their projects in various programming languages in Windows OS.