### PR TITLE
Initial support LLVM Intel in Windows

### DIFF
--- a/co_sim_io/includes/communication/pipe_communication.hpp
+++ b/co_sim_io/includes/communication/pipe_communication.hpp
@@ -108,13 +108,17 @@ public:
 
 
 private:
+    #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
     int mPipeHandleWrite;
     int mPipeHandleRead;
+    #endif
 
     fs::path mPipeNameWrite;
     fs::path mPipeNameRead;
 
+    #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
     std::size_t mBufferSize;
+    #endif
 
     void SendSize(const std::uint64_t Size);
 

--- a/co_sim_io/sources/communication/pipe_communication.cpp
+++ b/co_sim_io/sources/communication/pipe_communication.cpp
@@ -114,7 +114,10 @@ PipeCommunication::BidirectionalPipe::BidirectionalPipe(
     const fs::path& rBasePipeName,
     const bool IsPrimary,
     const int BufferSize,
-    const int EchoLevel) : mBufferSize(BufferSize)
+    const int EchoLevel) 
+    #ifndef CO_SIM_IO_COMPILED_IN_WINDOWS
+    : mBufferSize(BufferSize)
+    #endif
 {
     mPipeNameWrite = mPipeNameRead = rPipeDir / rBasePipeName;
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -15,16 +15,11 @@ IF "%USE_INTEL_LLVM%"=="ON" (
     set CXX=icx-cl.exe
     @REM Only Ninja compiler is supported
     set CMAKE_GENERATOR=Ninja
-) ELSE (
-    set CC=cl.exe
-    set CXX=cl.exe
-)
-
-rem Set defaults
-IF "%USE_INTEL_LLVM%"=="ON" (
     @REM Intel LLVM compiler fails with strict compiler
     if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=OFF 
 ) ELSE (
+    set CC=cl.exe
+    set CXX=cl.exe
     if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
 )
 

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -21,7 +21,12 @@ IF "%USE_INTEL_LLVM%"=="ON" (
 )
 
 rem Set defaults
-if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
+IF "%USE_INTEL_LLVM%"=="ON" (
+    @REM Intel LLVM compiler fails with strict compiler
+    if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=OFF 
+) ELSE (
+    if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON
+)
 
 rem Set basic configuration
 if not defined COSIMIO_BUILD_TYPE set COSIMIO_BUILD_TYPE=Release

--- a/scripts/build.bat
+++ b/scripts/build.bat
@@ -1,15 +1,24 @@
 @echo off
 rem Please do not modify this script. Copy it into the build folder
 
-rem Set compiler
-set CC=cl.exe
-set CXX=cl.exe
-
 rem Set variables
+if not defined USE_INTEL_LLVM set USE_INTEL_LLVM="OFF"
 if not defined CMAKE_GENERATOR set CMAKE_GENERATOR=Visual Studio 16 2019
 if not defined NUMBER_OF_COMPILATION_CORES set NUMBER_OF_COMPILATION_CORES=%NUMBER_OF_PROCESSORS%
 if not defined COSIMIO_SOURCE set COSIMIO_SOURCE=%~dp0..
 if not defined COSIMIO_BUILD set COSIMIO_BUILD=%COSIMIO_SOURCE%/build
+
+rem oneAPI call and set compiler
+IF "%USE_INTEL_LLVM%"=="ON" (
+    call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
+    set CC=icx-cl.exe
+    set CXX=icx-cl.exe
+    @REM Only Ninja compiler is supported
+    set CMAKE_GENERATOR=Ninja
+) ELSE (
+    set CC=cl.exe
+    set CXX=cl.exe
+)
 
 rem Set defaults
 if not defined CO_SIM_IO_STRICT_COMPILER set CO_SIM_IO_STRICT_COMPILER=ON


### PR DESCRIPTION
This PR updates the 'scripts/build.bat' file. The changes include setting the compiler variables 'CC' and 'CXX' based on the value of 'USE_INTEL_LLVM', and adjusting the 'CO_SIM_IO_STRICT_COMPILER' setting accordingly. When 'USE_INTEL_LLVM' is 'ON', it sets the compiler to 'icx-cl.exe' and turns off the strict compiler mode, as the Intel LLVM compiler fails with strict compiler settings. 

When 'USE_INTEL_LLVM' is 'OFF', it sets the compiler to 'cl.exe' and turns on the strict compiler mode. 

These changes are required fir for proper compilation on Windows systems when using the Intel LLVM compiler.