### PR TITLE
[CMake] Solution for linking `filesystem` (`libstdc++fs`) issues with GCC8 in Centos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ elseif(${CMAKE_COMPILER_IS_GNUCXX})
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override -Wignored-qualifiers")
     endif()
 
+    # Always link with libstdc++fs.a when using GCC 8.
+    # Note: This command makes sure that this option comes pretty late on the cmdline.
+    link_libraries( "$<$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9.0>>:-lstdc++fs>" )
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c89")


### PR DESCRIPTION
**📝 Description**

In this PR, the `CMakeLists.txt` file is modified to add support for linking the `libstdc++fs` library when using GCC 8 as the C++ compiler. 

This change is made based on a solution found in the following source: [Link to the discussion](https://discourse.cmake.org/t/correct-way-to-link-std-filesystem-with-gcc-8/4121/6). 

The modification is done by adding the `link_libraries` command with a conditional check to ensure it only applies when the C++ compiler is GNU (GCC) and has a version less than 9.0. 

The purpose of this modification is to ensure that the `libstdc++fs` library is linked appropriately when compiling with GCC 8.

**🆕 Changelog**

- [Solution for linking `filesystem` issues with GCC8 in Centos](https://github.com/KratosMultiphysics/CoSimIO/commit/7481169f68f9134945b70f54529dfb6ab9f03114)