### PR TITLE
[Communication] Move `BaseSocketCommunication` destructor to header to fix C++20 compilation

### DIFF
--- a/co_sim_io/includes/communication/base_socket_communication.hpp
+++ b/co_sim_io/includes/communication/base_socket_communication.hpp
@@ -39,7 +39,19 @@ public:
         std::shared_ptr<DataCommunicator> I_DataComm)
         : Communication(I_Settings, I_DataComm) {}
 
-    ~BaseSocketCommunication() override;
+    /// Destructor
+    ~BaseSocketCommunication() override
+    {
+        CO_SIM_IO_TRY
+
+        if (GetIsConnected()) {
+            CO_SIM_IO_INFO("CoSimIO") << "Warning: Disconnect was not performed, attempting automatic disconnection!" << std::endl;
+            Info tmp;
+            Disconnect(tmp);
+        }
+
+        CO_SIM_IO_CATCH
+    }
 
     Info ConnectDetail(const Info& I_Info) override;
 

--- a/co_sim_io/sources/communication/base_socket_communication.cpp
+++ b/co_sim_io/sources/communication/base_socket_communication.cpp
@@ -19,20 +19,6 @@ namespace CoSimIO {
 namespace Internals {
 
 template<class TSocketType>
-BaseSocketCommunication<TSocketType>::~BaseSocketCommunication()
-{
-    CO_SIM_IO_TRY
-
-    if (GetIsConnected()) {
-        CO_SIM_IO_INFO("CoSimIO") << "Warning: Disconnect was not performed, attempting automatic disconnection!" << std::endl;
-        Info tmp;
-        Disconnect(tmp);
-    }
-
-    CO_SIM_IO_CATCH
-}
-
-template<class TSocketType>
 Info BaseSocketCommunication<TSocketType>::ConnectDetail(const Info& I_Info)
 {
     CO_SIM_IO_TRY


### PR DESCRIPTION
# **📝 Description**

Move `BaseSocketCommunication` destructor to header to fix C++20 compilation. See for example: https://github.com/KratosMultiphysics/Kratos/actions/runs/18677406599/job/53257969885?pr=13549

#  **🆕 Changelog**

- [Move `BaseSocketCommunication` destructor to header to fix C++20 compilation](https://github.com/KratosMultiphysics/CoSimIO/commit/be0644af07871b788c7bee600ec8dc2e0a7fccf9)
